### PR TITLE
Postman auth client

### DIFF
--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -82,6 +82,17 @@ class AppAuthClient(BaseAuthClient):
     allowed_groups: list[GroupType] | None = None
 
 
+class PostmanAuthClient(BaseAuthClient):
+    """
+    An auth client for Postman
+    """
+
+    # Set of scopes the auth client is authorized to grant when issuing an access token.
+    # See app.utils.types.scopes_type.ScopeType for possible values
+    # WARNING: to be able to use openid connect, `ScopeType.openid` should always be allowed
+    allowed_scopes: Set[ScopeType] = {ScopeType.API}
+
+
 class NextcloudAuthClient(BaseAuthClient):
     # If no redirect_uri are hardcoded, the client will need to provide one in its request
     redirect_uri: str | None = None


### PR DESCRIPTION
To test endpoints requiring authentication using [Postman](https://www.postman.com/) we can use this `PostmanAuthClient`.

1. Register the client in Hyperion dotenv `.env`:
```python
AUTH_CLIENTS=[["Postman", "PostmanSecret", "PostmanAuthClient"]]
```

2. Configure Postman to use `OAuth 2.0` authorization:
> Grant Type: `Authorization code`
> [x] Authorize using browser
> Auth URL: http://127.0.0.1:8000/auth/authorize
> Access Token URL: http://127.0.0.1:8000/auth/token
> Client ID: `Postman`
> Client Secret: `PostmanSecret`
> Scope: `API`

