### PR TITLE
Return a 204 http code when succeeding a PATCH request

### DIFF
--- a/app/endpoints/bdebooking.py
+++ b/app/endpoints/bdebooking.py
@@ -152,7 +152,9 @@ async def create_bookings(
 
 
 @router.patch(
-    "/bdebooking/bookings/{booking_id}", status_code=200, tags=[Tags.bdebooking]
+    "/bdebooking/bookings/{booking_id}",
+    status_code=204,
+    tags=[Tags.bdebooking],
 )
 async def edit_bookings_id(
     booking_id: str,
@@ -175,7 +177,7 @@ async def edit_bookings_id(
 
 @router.patch(
     "/bdebooking/bookings/{booking_id}/reply/{decision}",
-    status_code=200,
+    status_code=204,
     tags=[Tags.bdebooking],
 )
 async def confirm_booking(
@@ -270,7 +272,7 @@ async def create_room(
 
 @router.patch(
     "/bdebooking/rooms/{room_id}",
-    status_code=200,
+    status_code=204,
     tags=[Tags.bdebooking],
 )
 async def edit_room(

--- a/app/endpoints/users.py
+++ b/app/endpoints/users.py
@@ -624,8 +624,7 @@ async def read_user(
 
 @router.patch(
     "/users/me",
-    response_model=schemas_core.CoreUser,
-    status_code=200,
+    status_code=204,
     tags=[Tags.users],
 )
 async def update_current_user(
@@ -641,13 +640,10 @@ async def update_current_user(
 
     await cruds_users.update_user(db=db, user_id=user.id, user_update=user_update)
 
-    return user
-
 
 @router.patch(
     "/users/{user_id}",
-    response_model=schemas_core.CoreUser,
-    status_code=200,
+    status_code=204,
     tags=[Tags.users],
 )
 async def update_user(
@@ -666,8 +662,6 @@ async def update_user(
         raise HTTPException(status_code=404, detail="User not found")
 
     await cruds_users.update_user(db=db, user_id=user_id, user_update=user_update)
-
-    return db_user
 
 
 @router.post(

--- a/tests/test_bdebooking.py
+++ b/tests/test_bdebooking.py
@@ -116,7 +116,7 @@ def test_edit_booking():
         json={"reason": "Pas un test"},
         headers={"Authorization": f"Bearer {token_bde}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 def test_reply_booking():
@@ -124,7 +124,7 @@ def test_reply_booking():
         f"/bdebooking/bookings/{booking.id}/reply/declined",
         headers={"Authorization": f"Bearer {token_bde}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 def test_delete_booking():
@@ -166,7 +166,7 @@ def test_edit_room():
         json={"name": "Foyer"},
         headers={"Authorization": f"Bearer {token_bde}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 def test_delete_room():

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -66,7 +66,7 @@ def test_update_current_user():
         json={"name": "NewName2"},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 def test_update_user():
@@ -87,7 +87,7 @@ def test_update_user():
         json={"name": "NewName"},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 204
 
 
 def test_create_current_user_profile_picture():


### PR DESCRIPTION
### Description

Titan would support PATCH requests to return either 204 No Content or 200 with the modified object. 
Unless Titan specifically requires the modified to be returned, in an effort of uniformization, let Hyperion return 204.