### PR TITLE
Fix Redis' dependency so that the app doesn't crash when ran in local…

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -125,6 +125,8 @@ def get_redis_client(
                 hyperion_error_logger.warning(
                     "Redis connection error: Check the Redis configuration or the Redis server"
                 )
+        else:
+            redis_client = False
     return redis_client
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -77,7 +77,7 @@ async def logging_middleware(
     settings: Settings = app.dependency_overrides.get(get_settings, get_settings)()
     redis_client: redis.Redis | Literal[False] | None = app.dependency_overrides.get(
         get_redis_client, get_redis_client
-    )()
+    )(settings=settings)
 
     # We test the ip address with the redis limiter
     process = True


### PR DESCRIPTION
… without a redis instance

### Description

Fix Redis' dependency so that the app doesn't crash when ran in local without a redis instance.

### Checklist
- [x] All tests passing
