### PR TITLE
Create cash if not exists when ordering

### DIFF
--- a/app/endpoints/amap.py
+++ b/app/endpoints/amap.py
@@ -457,6 +457,10 @@ async def add_order_to_delievery(
         balance = models_amap.Cash(
             **new_cash_db.dict(),
         )
+        await cruds_amap.create_cash_of_user(
+            cash=balance,
+            db=db,
+        )
 
     if not amount:
         raise HTTPException(status_code=403, detail="You can't order nothing")


### PR DESCRIPTION
### Description

Cash should be created when ordering if it does not exist already. Allow users to order before the admin increased its balance

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
