### PR TITLE
Replace timezone without changing time when creating icalendar

### DIFF
--- a/app/cruds/cruds_calendar.py
+++ b/app/cruds/cruds_calendar.py
@@ -142,9 +142,11 @@ async def create_icalendar_file(
             ical_event.add("summary", event.name)
             ical_event.add("description", event.description)
             ical_event.add(
-                "dtstart", event.start.astimezone(timezone(settings.TIMEZONE))
+                "dtstart", event.start.replace(tzinfo=timezone(settings.TIMEZONE))
             )
-            ical_event.add("dtend", event.end.astimezone(timezone(settings.TIMEZONE)))
+            ical_event.add(
+                "dtend", event.end.replace(tzinfo=timezone(settings.TIMEZONE))
+            )
             ical_event.add("dtstamp", datetime.now(timezone(settings.TIMEZONE)))
             ical_event.add("class", "public")
             ical_event.add("organizer", event.organizer)


### PR DESCRIPTION
### Description

Edit the timezone without changing time when creating icalendar.
This assumes that the start and end times of calendar events are wrongly set in UTC, because Titan does not support timezones at this time.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
