### PR TITLE
Test CORS configuration

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,10 @@ AUTH_ISSUER = "hyperion"
 
 # Logging configuration #
 LOG_DEBUG_MESSAGES=true
-CORS_ORIGINS=[]
+
+# CORS_ORIGINS should be a list of urls allowed to make requests to the API
+# It should begin with 'http://' or 'https:// and should never end with a '/'
+CORS_ORIGINS=["http://localhost"]
 
 # Matrix configuration #
 #MATRIX_SERVER_BASE_URL = ""

--- a/.env.test
+++ b/.env.test
@@ -19,6 +19,9 @@ AUTH_ISSUER = "hyperion"
 
 # Logging configuration #
 LOG_DEBUG_MESSAGES = True
+
+# CORS_ORIGINS should be a list of urls allowed to make requests to the API
+# It should begin with 'http://' or 'https:// and should never end with a '/'
 CORS_ORIGINS=["https://test-authorized-origin.com"]
 
 # Matrix configuration #

--- a/.env.test
+++ b/.env.test
@@ -19,7 +19,7 @@ AUTH_ISSUER = "hyperion"
 
 # Logging configuration #
 LOG_DEBUG_MESSAGES = True
-CORS_ORIGINS=[]
+CORS_ORIGINS=["https://test-authorized-origin.com"]
 
 # Matrix configuration #
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -86,6 +86,7 @@ class Settings(BaseSettings):
 
     # Origins for the CORS middleware. `["http://localhost"]` can be used for development.
     # See https://fastapi.tiangolo.com/tutorial/cors/
+    # It should begin with 'http://' or 'https:// and should never end with a '/'
     CORS_ORIGINS: list[str]
 
     ###################

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,3 +63,24 @@ def test_get_favicon():
         "/favicon.ico",
     )
     assert response.status_code == 200
+
+
+def test_cors_authorized_origin():
+    origin = "https://test-authorized-origin.com"
+    headers = {
+        "Access-Control-Request-Method": "GET",
+        "origin": origin,
+    }
+    response = client.get("/information", headers=headers)
+    assert response.headers["access-control-allow-origin"] == origin
+
+
+def test_cors_unauthorized_origin():
+    origin = "https://test-UNauthorized-origin.com"
+    headers = {
+        "Access-Control-Request-Method": "GET",
+        "origin": origin,
+    }
+    response = client.get("/information", headers=headers)
+    # The origin should not be in the response as it is not authorized. We will check `None != origin`
+    assert response.headers.get("access-control-allow-origin", None) != origin


### PR DESCRIPTION
 - configure CORS middleware after startup to allow tests to use the mocked Config class
 - add a test for CORS success and failure
 - document allowed origins format