### PR TITLE
get_file_from_data mitigation

### DIFF
--- a/app/endpoints/campaign.py
+++ b/app/endpoints/campaign.py
@@ -716,6 +716,7 @@ async def create_campaigns_logo(
 )
 async def read_campaigns_logo(
     list_id: str,
+    user: models_core.CoreUser = Depends(is_user_a_member_of(GroupType.AE)),
 ):
     """
     Get the logo of a campaign list.

--- a/app/endpoints/cinema.py
+++ b/app/endpoints/cinema.py
@@ -117,6 +117,7 @@ async def create_campaigns_logo(
 )
 async def read_session_poster(
     session_id: str,
+    user: models_core.CoreUser = Depends(is_user_a_member),
 ):
     return get_file_from_data(
         default_asset="assets/images/default_movie.png",

--- a/app/endpoints/core.py
+++ b/app/endpoints/core.py
@@ -112,11 +112,19 @@ async def get_style_file(
     """
     Return a style file from the assets folder
     """
+    css_dir = "assets/style/"
+    css_path = f"{css_dir}{file}.css"
 
-    if not path.isfile(f"assets/style/{file}.css"):
+    # Security check (even if FastAPI parsing of path parameters does not allow path traversal)
+    if path.commonprefix(
+        (path.realpath(css_path), path.realpath(css_dir))
+    ) != path.realpath(css_dir):
         raise HTTPException(status_code=404, detail="File not found")
 
-    return FileResponse(f"assets/style/{file}.css")
+    if not path.isfile(css_path):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(css_path)
 
 
 @router.get(

--- a/app/endpoints/raffle.py
+++ b/app/endpoints/raffle.py
@@ -253,6 +253,7 @@ async def create_current_raffle_logo(
 )
 async def read_raffle_logo(
     raffle_id: str,
+    user: models_core.CoreUser = Depends(is_user_a_member),
 ):
     """
     Get the logo of a specific raffle.
@@ -800,6 +801,7 @@ async def create_prize_picture(
 )
 async def read_prize_logo(
     prize_id: str,
+    user: models_core.CoreUser = Depends(is_user_a_member),
 ):
     """
     Get the logo of a specific prize.

--- a/app/endpoints/users.py
+++ b/app/endpoints/users.py
@@ -872,6 +872,7 @@ async def read_own_profile_picture(
 )
 async def read_user_profile_picture(
     user_id: str,
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Get the profile picture of an user.
@@ -879,8 +880,9 @@ async def read_user_profile_picture(
     Unauthenticated users can use this endpoint (needed for some OIDC services)
     """
 
-    # user_id should not contains wildcards, which could interpreted by glob.glob (https://docs.python.org/fr/3.10/library/glob.html)
-    user_id = user_id.replace("*", "")
+    db_user = await cruds_users.get_user_by_id(db=db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
 
     return get_file_from_data(
         directory="profile-pictures",

--- a/app/endpoints/users.py
+++ b/app/endpoints/users.py
@@ -879,6 +879,9 @@ async def read_user_profile_picture(
     Unauthenticated users can use this endpoint (needed for some OIDC services)
     """
 
+    # user_id should not contains wildcards, which could interpreted by glob.glob (https://docs.python.org/fr/3.10/library/glob.html)
+    user_id = user_id.replace("*", "")
+
     return get_file_from_data(
         directory="profile-pictures",
         filename=str(user_id),

--- a/app/utils/tools.py
+++ b/app/utils/tools.py
@@ -117,6 +117,8 @@ async def save_file_as_data(
      - webp
 
     An HTTP Exception will be raised if an error occurres.
+
+    WARNING: **NEVER** trust user input when calling this function. Always check that parameters are valid.
     """
     if image.content_type not in accepted_content_types:
         raise HTTPException(
@@ -169,6 +171,8 @@ def get_file_from_data(
     If there is a file with the provided filename in the data folder, return it. The file extension will be inferred from the provided content file.
     > "data/{directory}/{filename}.ext"
     Otherwise, return the default asset.
+
+    WARNING: **NEVER** trust user input when calling this function. Always check that parameters are valid.
     """
     for filePath in glob.glob(f"data/{directory}/{filename}.*"):
         return FileResponse(filePath)


### PR DESCRIPTION
### Description

Mitigate few security issues related to `get_file_from_data`:
- on some modules, endpoints are accessible for unauthenticated users
- wildcards interpreted by glob.glob() can be exploited to enumerate user ids and profile pictures without being authenticated

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
