### PR TITLE
Fix adding first advert

### DIFF
--- a/app/endpoints/advert.py
+++ b/app/endpoints/advert.py
@@ -251,6 +251,7 @@ async def create_advert(
     db_advert = models_advert.Advert(
         id=str(uuid.uuid4()),
         date=datetime.now(timezone(settings.TIMEZONE)),
+        advertiser=advertiser,
         **advert_params,
     )
 


### PR DESCRIPTION
### Description

Solve issue when creating first advert for a new advertiser.

Lazy loading of advert.advertiser was not working properly in this case. Just adding advertiser before adding the object to the database works properly.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
