### PR TITLE
Fix notifications

### DIFF
--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -241,7 +241,7 @@ async def get_topic_memberships_by_user_id_and_topic(
     user_id: str,
     custom_topic: CustomTopic,
     db: AsyncSession,
-) -> models_notification.TopicMembership | None:
+) -> Sequence[models_notification.TopicMembership]:
     result = await db.execute(
         select(models_notification.TopicMembership).where(
             models_notification.TopicMembership.user_id == user_id,

--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -246,7 +246,7 @@ async def get_topic_memberships_with_identifiers_by_user_id_and_topic(
         select(models_notification.TopicMembership).where(
             models_notification.TopicMembership.user_id == user_id,
             models_notification.TopicMembership.topic == topic,
-            models_notification.TopicMembership.topic_identifier.is_not(None),
+            models_notification.TopicMembership.topic_identifier != "",
         )
     )
     return result.scalars().all()

--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -246,7 +246,7 @@ async def get_topic_memberships_with_identifiers_by_user_id_and_topic(
         select(models_notification.TopicMembership).where(
             models_notification.TopicMembership.user_id == user_id,
             models_notification.TopicMembership.topic == topic,
-            models_notification.TopicMembership.topic_identifier is not None,
+            models_notification.TopicMembership.topic_identifier.is_not(None),
         )
     )
     return result.scalars().all()

--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -237,7 +237,7 @@ async def get_topic_memberships_by_user_id(
     return result.scalars().all()
 
 
-async def get_topic_memberships_by_user_id_and_topic(
+async def get_topic_memberships_with_identifiers_by_user_id_and_topic(
     user_id: str,
     topic: Topic,
     db: AsyncSession,
@@ -246,6 +246,7 @@ async def get_topic_memberships_by_user_id_and_topic(
         select(models_notification.TopicMembership).where(
             models_notification.TopicMembership.user_id == user_id,
             models_notification.TopicMembership.topic == topic,
+            models_notification.TopicMembership.topic_identifier is not None,
         )
     )
     return result.scalars().all()

--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -211,7 +211,7 @@ async def delete_topic_membership(
     await db.commit()
 
 
-async def get_topic_membership_by_topic(
+async def get_topic_memberships_by_topic(
     custom_topic: CustomTopic,
     db: AsyncSession,
 ) -> Sequence[models_notification.TopicMembership]:
@@ -225,7 +225,7 @@ async def get_topic_membership_by_topic(
     return result.scalars().all()
 
 
-async def get_topic_membership_by_user_id(
+async def get_topic_memberships_by_user_id(
     user_id: str,
     db: AsyncSession,
 ) -> Sequence[models_notification.TopicMembership]:
@@ -237,7 +237,21 @@ async def get_topic_membership_by_user_id(
     return result.scalars().all()
 
 
-async def get_topic_membership_by_user_id_and_topic(
+async def get_topic_memberships_by_user_id_and_topic(
+    user_id: str,
+    custom_topic: CustomTopic,
+    db: AsyncSession,
+) -> models_notification.TopicMembership | None:
+    result = await db.execute(
+        select(models_notification.TopicMembership).where(
+            models_notification.TopicMembership.user_id == user_id,
+            models_notification.TopicMembership.topic == custom_topic.topic,
+        )
+    )
+    return result.scalars().all()
+
+
+async def get_topic_membership_by_user_id_and_full_topic(
     user_id: str,
     custom_topic: CustomTopic,
     db: AsyncSession,

--- a/app/cruds/cruds_notification.py
+++ b/app/cruds/cruds_notification.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import models_notification
-from app.utils.types.notification_types import CustomTopic
+from app.utils.types.notification_types import CustomTopic, Topic
 
 
 async def create_message(
@@ -239,19 +239,19 @@ async def get_topic_memberships_by_user_id(
 
 async def get_topic_memberships_by_user_id_and_topic(
     user_id: str,
-    custom_topic: CustomTopic,
+    topic: Topic,
     db: AsyncSession,
 ) -> Sequence[models_notification.TopicMembership]:
     result = await db.execute(
         select(models_notification.TopicMembership).where(
             models_notification.TopicMembership.user_id == user_id,
-            models_notification.TopicMembership.topic == custom_topic.topic,
+            models_notification.TopicMembership.topic == topic,
         )
     )
     return result.scalars().all()
 
 
-async def get_topic_membership_by_user_id_and_full_topic(
+async def get_topic_membership_by_user_id_and_custom_topic(
     user_id: str,
     custom_topic: CustomTopic,
     db: AsyncSession,

--- a/app/endpoints/advert.py
+++ b/app/endpoints/advert.py
@@ -231,7 +231,7 @@ async def create_advert(
     db: AsyncSession = Depends(get_db),
     user: models_core.CoreUser = Depends(is_user_a_member),
     settings: Settings = Depends(get_settings),
-    notification_tool=Depends(get_notification_tool),
+    notification_tool: NotificationTool = Depends(get_notification_tool),
 ):
     """
     Create a new advert
@@ -282,7 +282,7 @@ async def create_advert(
         )
     except Exception as error:
         hyperion_error_logger.error(
-            f"Error while sending cinema recap notification, {error}"
+            f"Error while sending AMAP recap notification, {error}"
         )
 
     return result

--- a/app/endpoints/advert.py
+++ b/app/endpoints/advert.py
@@ -20,6 +20,7 @@ from app.dependencies import (
 from app.models import models_advert, models_core
 from app.schemas import schemas_advert
 from app.schemas.schemas_notification import Message
+from app.utils.communication.notifications import NotificationTool
 from app.utils.tools import (
     get_file_from_data,
     is_group_id_valid,

--- a/app/endpoints/advert.py
+++ b/app/endpoints/advert.py
@@ -273,7 +273,7 @@ async def create_advert(
         message = Message(
             context=f"advert-{result.id}",
             is_visible=True,
-            title=f"📣 {result.advertiser} - {result.title}",
+            title=f"📣 Annonce - {result.title}",
             content=result.content,
             # The notification will expire in 3 days
             expire_on=now.replace(day=now.day + 3),

--- a/app/endpoints/advert.py
+++ b/app/endpoints/advert.py
@@ -282,9 +282,7 @@ async def create_advert(
             custom_topic=CustomTopic(topic=Topic.advert), message=message
         )
     except Exception as error:
-        hyperion_error_logger.error(
-            f"Error while sending AMAP recap notification, {error}"
-        )
+        hyperion_error_logger.error(f"Error while sending advert notification, {error}")
 
     return result
 

--- a/app/endpoints/amap.py
+++ b/app/endpoints/amap.py
@@ -915,7 +915,7 @@ async def create_cash_of_user(
             )
     except Exception as error:
         hyperion_error_logger.error(
-            f"Error while sending cinema recap notification, {error}"
+            f"Error while sending AMAP notification, {error}"
         )
 
     return result

--- a/app/endpoints/amap.py
+++ b/app/endpoints/amap.py
@@ -914,9 +914,7 @@ async def create_cash_of_user(
                 message=message,
             )
     except Exception as error:
-        hyperion_error_logger.error(
-            f"Error while sending AMAP notification, {error}"
-        )
+        hyperion_error_logger.error(f"Error while sending AMAP notification, {error}")
 
     return result
 

--- a/app/endpoints/bdebooking.py
+++ b/app/endpoints/bdebooking.py
@@ -197,7 +197,7 @@ async def create_bookings(
                 # We use sunday date as context to avoid sending the recap twice
                 context=f"booking-create-{result.id}",
                 is_visible=True,
-                title="Réservations - Nouvelle réservation 📅",
+                title="📅 Réservation - Nouvelle réservation",
                 content=f"{result.applicant.nickname} - {result.room.name} {result.start.strftime('%m/%d/%Y, %H:%M')} - {result.reason}",
                 # The notification will expire the next sunday
                 expire_on=now.replace(day=now.day + 3),

--- a/app/endpoints/bdebooking.py
+++ b/app/endpoints/bdebooking.py
@@ -18,6 +18,7 @@ from app.dependencies import (
 from app.models import models_core
 from app.schemas import schemas_bdebooking
 from app.schemas.schemas_notification import Message
+from app.utils.communication.notifications import NotificationTool
 from app.utils.tools import is_user_member_of_an_allowed_group
 from app.utils.types.bdebooking_type import Decision
 from app.utils.types.groups_type import GroupType
@@ -173,7 +174,7 @@ async def create_bookings(
     db: AsyncSession = Depends(get_db),
     user: models_core.CoreUser = Depends(is_user_a_member),
     settings: Settings = Depends(get_settings),
-    notification_tool=Depends(get_notification_tool),
+    notification_tool: NotificationTool = Depends(get_notification_tool),
 ):
     """
     Create a booking.
@@ -202,12 +203,12 @@ async def create_bookings(
                 expire_on=now.replace(day=now.day + 3),
             )
             await notification_tool.send_notification_to_topic(
-                topic=CustomTopic(topic=Topic.bookingadmin),
+                custom_topic=CustomTopic(topic=Topic.bookingadmin),
                 message=message,
             )
     except Exception as error:
         hyperion_error_logger.error(
-            f"Error while sending cinema recap notification, {error}"
+            f"Error while sending booking notification, {error}"
         )
 
     return result

--- a/app/endpoints/cinema.py
+++ b/app/endpoints/cinema.py
@@ -82,7 +82,7 @@ async def create_session(
             # We use sunday date as context to avoid sending the recap twice
             context=f"cinema-recap-{sunday}",
             is_visible=True,
-            title="Cinéma - Programme de la semaine 🎬",
+            title="🎬 Cinéma - Programme de la semaine",
             content=message_content,
             delivery_datetime=sunday,
             # The notification will expire the next sunday

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -59,7 +59,7 @@ async def register_firebase_device(
         )
 
     # We also need to subscribe the new token to the topics the user is subscribed to
-    topic_memberships = await cruds_notification.get_topic_membership_by_user_id(
+    topic_memberships = await cruds_notification.get_topic_memberships_by_user_id(
         user_id=user.id, db=db
     )
 
@@ -102,7 +102,7 @@ async def unregister_firebase_device(
     # Anybody may unregister a device if they know its token, which should be secret
 
     # We also need to unsubscribe the token to the topics the user is subscribed to
-    topic_memberships = await cruds_notification.get_topic_membership_by_user_id(
+    topic_memberships = await cruds_notification.get_topic_memberships_by_user_id(
         user_id=user.id, db=db
     )
 
@@ -231,7 +231,7 @@ async def get_topic(
     **The user must be authenticated to use this endpoint**
     """
 
-    memberships = await cruds_notification.get_topic_membership_by_user_id(
+    memberships = await cruds_notification.get_topic_memberships_by_user_id(
         user_id=user.id, db=db
     )
 
@@ -255,7 +255,7 @@ async def get_topic_identifier(
     **The user must be authenticated to use this endpoint**
     """
 
-    memberships = await cruds_notification.get_topic_membership_by_user_id_and_topic(
+    memberships = await cruds_notification.get_topic_memberships_by_user_id_and_topic(
         user_id=user.id, db=db, custom_topic=CustomTopic.from_str(topic_str)
     )
 

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -15,7 +15,7 @@ from app.models import models_core, models_notification
 from app.schemas import schemas_notification
 from app.utils.communication.notifications import NotificationManager, NotificationTool
 from app.utils.types.groups_type import GroupType
-from app.utils.types.notification_types import CustomTopic
+from app.utils.types.notification_types import CustomTopic, Topic
 from app.utils.types.tags import Tags
 
 router = APIRouter()
@@ -261,7 +261,7 @@ async def get_topic_identifier(
     """
 
     memberships = await cruds_notification.get_topic_memberships_by_user_id_and_topic(
-        user_id=user.id, db=db, custom_topic=CustomTopic.from_str(topic_str)
+        user_id=user.id, db=db, custom_topic=Topic(topic_str)
     )
 
     return [

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -235,6 +235,30 @@ async def get_topic(
         user_id=user.id, db=db
     )
 
+    return [CustomTopic(topic=membership.topic).to_str() for membership in memberships]
+
+
+@router.get(
+    "/notification/topics/{topic_str}",
+    status_code=200,
+    tags=[Tags.notifications],
+    response_model=list[str],
+)
+async def get_topic_identifier(
+    topic_str: str,
+    db: AsyncSession = Depends(get_db),
+    user: models_core.CoreUser = Depends(is_user_a_member),
+):
+    """
+    Get full topic (with identifiers) the user is subscribed to
+
+    **The user must be authenticated to use this endpoint**
+    """
+
+    memberships = await cruds_notification.get_topic_membership_by_user_id_and_topic(
+        user_id=user.id, db=db, custom_topic=CustomTopic.from_str(topic_str)
+    )
+
     return [
         CustomTopic(
             topic=membership.topic, topic_identifier=membership.topic_identifier

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -261,7 +261,7 @@ async def get_topic_identifier(
     """
 
     memberships = await cruds_notification.get_topic_memberships_by_user_id_and_topic(
-        user_id=user.id, db=db, custom_topic=Topic(topic_str)
+        user_id=user.id, db=db, topic=Topic(topic_str)
     )
 
     return [

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -255,12 +255,12 @@ async def get_topic_identifier(
     user: models_core.CoreUser = Depends(is_user_a_member),
 ):
     """
-    Get full topic (with identifiers) the user is subscribed to
+    Get custom topic (with identifiers) the user is subscribed to
 
     **The user must be authenticated to use this endpoint**
     """
 
-    memberships = await cruds_notification.get_topic_memberships_by_user_id_and_topic(
+    memberships = await cruds_notification.get_topic_memberships_with_identifiers_by_user_id_and_topic(
         user_id=user.id, db=db, topic=Topic(topic_str)
     )
 

--- a/app/endpoints/notification.py
+++ b/app/endpoints/notification.py
@@ -227,6 +227,7 @@ async def get_topic(
 ):
     """
     Get topics the user is subscribed to
+    Does not return session topics (those with a topic_identifier)
 
     **The user must be authenticated to use this endpoint**
     """
@@ -235,7 +236,11 @@ async def get_topic(
         user_id=user.id, db=db
     )
 
-    return [CustomTopic(topic=membership.topic).to_str() for membership in memberships]
+    return [
+        CustomTopic(topic=membership.topic).to_str()
+        for membership in memberships
+        if not membership.topic_identifier
+    ]
 
 
 @router.get(

--- a/app/models/models_notification.py
+++ b/app/models/models_notification.py
@@ -31,7 +31,9 @@ class Message(Base):
     action_table: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # We can plan a notification to be sent later, the frontend should not display it before the planned date
-    delivery_datetime: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    delivery_datetime: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     # Messages should be deleted after a certain time
     expire_on: Mapped[date] = mapped_column(Date, nullable=False)
 

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -313,7 +313,7 @@ class NotificationManager:
             )
 
         existing_topic_membership = (
-            await cruds_notification.get_topic_membership_by_user_id_and_full_topic(
+            await cruds_notification.get_topic_membership_by_user_id_and_custom_topic(
                 custom_topic=custom_topic, user_id=user_id, db=db
             )
         )

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -161,7 +161,9 @@ class NotificationManager:
             custom_topic=custom_topic, data={"trigger": "trigger"}
         )
 
-    def subscribe_tokens_to_topic(self, custom_topic: CustomTopic, tokens: list[str]):
+    async def subscribe_tokens_to_topic(
+        self, custom_topic: CustomTopic, tokens: list[str]
+    ):
         """
         Subscribe a list of tokens to a given topic.
         """
@@ -174,7 +176,9 @@ class NotificationManager:
                 f"Notification: Failed to subscribe to topic {custom_topic} due to {list(map(lambda e: e.reason,response.errors))}"
             )
 
-    def unsubscribe_tokens_to_topic(self, custom_topic: CustomTopic, tokens: list[str]):
+    async def unsubscribe_tokens_to_topic(
+        self, custom_topic: CustomTopic, tokens: list[str]
+    ):
         """
         Unsubscribe a list of tokens to a given topic.
         """

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -264,7 +264,7 @@ class NotificationManager:
             return
 
         # Get all firebase_device_token related to the user
-        topic_memberships = await cruds_notification.get_topic_membership_by_topic(
+        topic_memberships = await cruds_notification.get_topic_memberships_by_topic(
             custom_topic=custom_topic,
             db=db,
         )
@@ -308,12 +308,12 @@ class NotificationManager:
 
         if len(firebase_device_tokens) > 0:
             # Asking firebase to subscribe with an empty list of tokens will raise an error
-            self.subscribe_tokens_to_topic(
+            await self.subscribe_tokens_to_topic(
                 tokens=firebase_device_tokens, custom_topic=custom_topic
             )
 
         existing_topic_membership = (
-            await cruds_notification.get_topic_membership_by_user_id_and_topic(
+            await cruds_notification.get_topic_membership_by_user_id_and_full_topic(
                 custom_topic=custom_topic, user_id=user_id, db=db
             )
         )
@@ -345,7 +345,7 @@ class NotificationManager:
 
         if len(firebase_device_tokens) > 0:
             # Asking firebase to unsubscribe with an empty list of tokens will raise an error
-            self.unsubscribe_tokens_to_topic(
+            await self.unsubscribe_tokens_to_topic(
                 tokens=firebase_device_tokens, custom_topic=custom_topic
             )
 

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -64,7 +64,7 @@ class NotificationManager:
                 f"{response.failure_count} messages failed to be send, removing their tokens from the database."
             )
             await cruds_notification.batch_delete_firebase_device_by_token(
-                tokens=tokens, db=db
+                tokens=failed_tokens, db=db
             )
 
     async def _send_firebase_push_notification_by_tokens(

--- a/app/utils/types/notification_types.py
+++ b/app/utils/types/notification_types.py
@@ -24,9 +24,9 @@ class CustomTopic:
 
     def to_str(self) -> str:
         if self.topic_identifier:
-            return f"{self.topic}_{self.topic_identifier}"
+            return f"{self.topic.value}_{self.topic_identifier}"
         else:
-            return str(self.topic)
+            return self.topic.value
 
     @classmethod
     def from_str(cls, topic_str: str):


### PR DESCRIPTION
### Description

- Various fix when calling send_notification_to_user
- Fix notifications title
- Fix CustomTopic to_str() which lead to send wrongly formatted topic names to Titan
- Add get_topit_identifier to get full topic name (with identifiers) the user is subscribed to for a given topic
-  Rename get_topic_membership_XX to plural & add get_topic_memberships_by_user_id_and_topic

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
