### PR TITLE
Delete Blank list after removing Votes

### DIFF
--- a/app/cruds/cruds_campaign.py
+++ b/app/cruds/cruds_campaign.py
@@ -330,7 +330,7 @@ async def delete_votes(db: AsyncSession) -> None:
 async def reset_campaign(db: AsyncSession) -> None:
     """Reset the campaign.
     This will delete all the votes and blank list lists."""
-    await delete_list_by_type(ListType.blank, db)
     await db.execute(delete(models_campaign.Votes))
     await db.execute(delete(models_campaign.HasVoted))
     await db.commit()
+    await delete_list_by_type(ListType.blank, db)


### PR DESCRIPTION
to not delete a list when Votes are still referring to it as a foreign key

### Description

This prevent a SQLAlchemy error
```
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) : update or delete on table "campaign_lists" violates foreign key constraint "campaign_votes_list_id_fkey" on table "campaign_votes" | DETAIL: Key (id)=(84073848-4167-42e4-91fb-b090aad3087d) is still referenced from table "campaign_votes". | [SQL: DELETE FROM campaign_lists WHERE campaign_lists.type = $1::VARCHAR] | [parameters: (,)] | (Background on this error at: https://sqlalche.me/e/20/gkpj)
```
