### PR TITLE
Use bcrypt instead of passlib

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -47,7 +47,7 @@ def generate_token(nbytes=32) -> str:
 
 def get_password_hash(password: str) -> str:
     """
-    Return a salted hash computed from password. The function use a bcrypt based *passlib* CryptContext.
+    Return a salted hash computed from password.
     Both the salt and the algorithm identifier are included in the hash.
     """
     hashed = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(rounds=13))
@@ -56,9 +56,10 @@ def get_password_hash(password: str) -> str:
 
 def verify_password(plain_password: str, hashed_password: str | None) -> bool:
     """
-    Compare `plain_password` against its salted hash representation `hashed_password`. The function use a bcrypt based *passlib* CryptContext.
+    Compare `plain_password` against its salted hash representation `hashed_password`.
 
-    Pass hashed_password=None to simulate the delay a real verification would have taken. This is useful to limit timing attacks
+    We genrerate a fake_hash for the case where hashed_password=None (ie the email isn't valid) to simulate the delay a real verification would have taken.
+    This is useful to limit timing attacks that could be used to guess valid emails.
     """
     fake_hash = bcrypt.hashpw(generate_token(12).encode("utf-8"), bcrypt.gensalt(13))
     if hashed_password is None:

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -12,10 +12,9 @@ from app.models import models_core
 from app.schemas import schemas_auth
 
 """
-In order to salt and hash password, we use a *passlib* [CryptContext](https://passlib.readthedocs.io/en/stable/narr/quickstart.html) object.
+In order to salt and hash password, we the bcrypt hashing function (see https://en.wikipedia.org/wiki/Bcrypt).
 
-We use "bcrypt" to hash password, a different hash will be added automatically for each password. See [Auth0 Understanding bcrypt](https://auth0.com/blog/hashing-in-action-understanding-bcrypt/) for information about bcrypt.
-deprecated="auto" may be used to do password hash migration, see [Passlib hash migration](https://passlib.readthedocs.io/en/stable/narr/context-tutorial.html#deprecation-hash-migration).
+A different salt will be added automatically for each password. See [Auth0 Understanding bcrypt](https://auth0.com/blog/hashing-in-action-understanding-bcrypt/) for information about bcrypt.
 It is important to use enough rounds while accounting for the hash computation time. Default is 12. 13 allows for a 0.5 seconds computing delay.
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.11.3                      # database migrations
 fastapi==0.99.0
 Jinja2==3.1.2                       # template engine for html files
-passlib[bcrypt]==1.7.4              # password hashing using bcrypt
+bcrypt==4.0.1                       # password hashing
 python-dotenv==1.0.0               # load environment variables from .env file
 python-jose[cryptography]==3.3.0    # generate and verify the JWT tokens
 python-multipart==0.0.6             # a form data parser, as oauth flow requires form-data parameters


### PR DESCRIPTION
### Description

Use the bcrypt library for password hashing instead of passlib that used a deprecated dependency (crypt).

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
