### PR TITLE
Fix test_search_users

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -146,7 +146,9 @@ def test_search_users():
     )
     assert response.status_code == 200
     data_users = set(user["id"] for user in response.json())
-    assert data_users == group_users
+    assert (
+        data_users <= group_users
+    )  # This endpoint is limited to 10 members, so we only need an inclusion between the two sets, in case there are more than 10 members in the group.
 
     response = client.get(
         f"/users/search?query=&excludedGroups={group}",


### PR DESCRIPTION
### Description

Fixed test_users::test_search_users.
When there were more than 10 users in the students group, it would fail because it would try to compare all of the users from the group to the users returned by an endpoint that is limited to return up to 10 users only.
I've modified the test so that instead of a strict equality, it is now an inequality, meaning that the students returned by /users/search must be present in the group, but we don't need all of them

### Checklist

- [x] All tests passing
