### PR TITLE
Fix concurrency for coverage in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ omit = [
     "mailworker.py", # We don't use send mails during tests
     "*matrix*",      # We don't send logs to matrix during tests
 ]
+concurrency = [
+    "thread",
+    "greenlet",
+] # Tell the tool that we also use greenlet, because sqlalchemy does
 
 
 [tool.coverage.report]


### PR DESCRIPTION
### Description

The coverage tool does not automatically mark as covered the functions that use greenlet, so all the functions that used sqlalchemy were incorrectly marked as not covered.
This PR adds the relevant option in pyproject.toml.

