### PR TITLE
Fix black formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     },
     "python.testing.pytestArgs": ["tests"],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "black-formatter.path": [
+        "black"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "editor.detectIndentation": false,
     "python.analysis.typeCheckingMode": "off",
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     // We don't want VS Code to find our dotenv file, as the IDE is not cappable of parsing it correctly.
     // When using the debugger, VS Code pass the porly parsed file as environnement variables, letting to Pydantic validation erros

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -69,9 +69,7 @@ class Settings(BaseSettings):
     # PostgreSQL configuration #
     ############################
     # PostgreSQL configuration is needed to use the database
-    SQLITE_DB: str | None = (
-        None  # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
-    )
+    SQLITE_DB: str | None = None  # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
     POSTGRES_HOST: str
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
@@ -89,9 +87,7 @@ class Settings(BaseSettings):
     LOG_DEBUG_MESSAGES: bool | None
     # Hyperion follows Semantic Versioning
     # https://semver.org/
-    HYPERION_VERSION: str = (
-        "1.0.0"  # This value should never be modified by hand. See [Hyperion release] documentation
-    )
+    HYPERION_VERSION: str = "1.0.0"  # This value should never be modified by hand. See [Hyperion release] documentation
     MINIMAL_TITAN_VERSION_CODE: int = 100
     # Depreciated, minimal_titan_version_code should be used
     MINIMAL_TITAN_VERSION: str = "0.0.1"


### PR DESCRIPTION
### Description

Update VSCode workspace settings to fix black formatting issues.
VSCode "Black Formatter" extension ships with its own version of black. This PR enforces the use of the local install of black, which should match the `requirements-dev.txt`.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
