### PR TITLE
Tests notifications and send notifications for loan and booking

### DIFF
--- a/app/core/notification/endpoints_notification.py
+++ b/app/core/notification/endpoints_notification.py
@@ -254,12 +254,12 @@ async def get_topic(
 
 
 @router.get(
-    "/notification/topics/{topic_str}",
+    "/notification/topics/{topic}",
     status_code=200,
     response_model=list[str],
 )
 async def get_topic_identifier(
-    topic_str: str,
+    topic: Topic,
     db: AsyncSession = Depends(get_db),
     user: models_core.CoreUser = Depends(is_user_a_member),
 ):

--- a/app/core/notification/endpoints_notification.py
+++ b/app/core/notification/endpoints_notification.py
@@ -272,7 +272,7 @@ async def get_topic_identifier(
     memberships = await cruds_notification.get_topic_memberships_with_identifiers_by_user_id_and_topic(
         user_id=user.id,
         db=db,
-        topic=Topic(topic_str),
+        topic=topic,
     )
 
     return [

--- a/app/core/notification/notification_types.py
+++ b/app/core/notification/notification_types.py
@@ -8,7 +8,6 @@ class Topic(str, Enum):
 
     cinema = "cinema"
     advert = "advert"
-    bookingadmin = "bookingadmin"
     amap = "amap"
     booking = "booking"
     event = "event"

--- a/app/modules/booking/endpoints_booking.py
+++ b/app/modules/booking/endpoints_booking.py
@@ -270,10 +270,11 @@ async def create_booking(
     try:
         manager_group_id = result.room.manager.group_id
         manager_group = await cruds_groups.get_group_by_id(
-            db=db, group_id=manager_group_id
+            db=db,
+            group_id=manager_group_id,
         )
         if result and manager_group:
-            now = datetime.now(ZoneInfo(settings.TIMEZONE))
+            now = datetime.now(UTC)
             message = Message(
                 context=f"booking-create-{result.id}",
                 is_visible=True,
@@ -287,7 +288,7 @@ async def create_booking(
             )
     except Exception as error:
         hyperion_error_logger.error(
-            f"Error while sending booking admin notification, {error}"
+            f"Error while sending booking admin notification, {error}",
         )
 
     return result
@@ -369,7 +370,7 @@ async def confirm_booking(
 
     if decision in [Decision.approved, Decision.declined]:
         try:
-            now = datetime.now(ZoneInfo(settings.TIMEZONE))
+            now = datetime.now(UTC)
             status = "acceptée" if decision == Decision.approved else "refusée"
             message = Message(
                 context=f"booking-decision-{booking_id}",
@@ -384,7 +385,7 @@ async def confirm_booking(
             )
         except Exception as error:
             hyperion_error_logger.error(
-                f"Error while sending booking status notification to applicant, {error}"
+                f"Error while sending booking status notification to applicant, {error}",
             )
 
 

--- a/app/modules/booking/endpoints_booking.py
+++ b/app/modules/booking/endpoints_booking.py
@@ -329,7 +329,7 @@ async def edit_booking(
             db=db,
         )
     except ValueError as error:
-        raise HTTPException(status_code=422, detail=str(error))
+        raise HTTPException(status_code=400, detail=str(error))
 
 
 @module.router.patch(

--- a/app/modules/loan/endpoints_loan.py
+++ b/app/modules/loan/endpoints_loan.py
@@ -616,7 +616,7 @@ async def create_loan(
         )
 
     try:
-        now = datetime.now(ZoneInfo(settings.TIMEZONE))
+        now = datetime.now(UTC)
         message = Message(
             context=f"loan-new-{loan.id}",
             is_visible=True,
@@ -630,7 +630,7 @@ async def create_loan(
         )
     except Exception as error:
         hyperion_error_logger.error(
-            f"Error while sending notification to borrower of a new loan, {error}"
+            f"Error while sending notification to borrower of a new loan, {error}",
         )
 
     return schemas_loan.Loan(items_qty=items_qty_ret, **loan.__dict__)

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -293,11 +293,16 @@ class NotificationManager:
             )
 
     async def send_notification_to_users(
-        self, user_ids: list[str], message: Message, db: AsyncSession
+        self,
+        user_ids: list[str],
+        message: Message,
+        db: AsyncSession,
     ) -> None:
         for user_id in user_ids:
             await self.send_notification_to_user(
-                user_id=user_id, message=message, db=db
+                user_id=user_id,
+                message=message,
+                db=db,
             )
 
     async def send_notification_to_topic(

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -292,6 +292,14 @@ class NotificationManager:
                 f"Notification: Unable to send firebase notification to user {user_id} with device: {error}",
             )
 
+    async def send_notification_to_users(
+        self, user_ids: list[str], message: Message, db: AsyncSession
+    ) -> None:
+        for user_id in user_ids:
+            await self.send_notification_to_user(
+                user_id=user_id, message=message, db=db
+            )
+
     async def send_notification_to_topic(
         self,
         custom_topic: CustomTopic,
@@ -438,6 +446,14 @@ class NotificationTool:
         self.background_tasks.add_task(
             self.notification_manager.send_notification_to_user,
             user_id=user_id,
+            message=message,
+            db=self.db,
+        )
+
+    async def send_notification_to_users(self, user_ids: list[str], message: Message):
+        self.background_tasks.add_task(
+            self.notification_manager.send_notification_to_users,
+            user_ids=user_ids,
             message=message,
             db=self.db,
         )

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -4,8 +4,12 @@ from app.core import models_core
 from app.core.groups.groups_type import GroupType
 
 # We need to import event_loop for pytest-asyncio routine defined bellow
-from tests.commons import event_loop  # noqa
-from tests.commons import client, create_api_access_token, create_user_with_groups
+from tests.commons import (
+    client,
+    create_api_access_token,
+    create_user_with_groups,
+    event_loop,  # noqa
+)
 
 admin_user: models_core.CoreUser | None = None
 admin_user_token: str = ""
@@ -21,7 +25,6 @@ TOPIC_4 = "cinema_notsubscribed"
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
 async def init_objects():
-
     global admin_user, admin_user_token
     admin_user = await create_user_with_groups([GroupType.admin])
     admin_user_token = create_api_access_token(admin_user)

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,163 @@
+import pytest_asyncio
+
+from app.core import models_core
+from app.core.groups.groups_type import GroupType
+
+# We need to import event_loop for pytest-asyncio routine defined bellow
+from tests.commons import event_loop  # noqa
+from tests.commons import client, create_api_access_token, create_user_with_groups
+
+admin_user: models_core.CoreUser | None = None
+admin_user_token: str = ""
+
+FIREBASE_TOKEN_1 = "my-firebase-token"
+FIREBASE_TOKEN_2 = "my-second-firebase-token"
+
+TOPIC_1 = "cinema"
+TOPIC_2 = "cinema_4c029b5f-2bf7-4b70-85d4-340a4bd28653"
+TOPIC_3 = "cinema_2fa05a5b-43df-4ae6-8466-eeef649ac40e"
+TOPIC_4 = "cinema_notsubscribed"
+
+
+@pytest_asyncio.fixture(scope="module", autouse=True)
+async def init_objects():
+
+    global admin_user, admin_user_token
+    admin_user = await create_user_with_groups([GroupType.admin])
+    admin_user_token = create_api_access_token(admin_user)
+
+
+def test_register_firebase_device():
+    response = client.post(
+        "/notification/devices",
+        json={
+            "firebase_token": FIREBASE_TOKEN_1,
+        },
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_register_a_second_time_a_firebase_device():
+    # One user can and should register a device at least once a month
+    response = client.post(
+        "/notification/devices",
+        json={
+            "firebase_token": FIREBASE_TOKEN_1,
+        },
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_register_second_firebase_device():
+    response = client.post(
+        "/notification/devices",
+        json={
+            "firebase_token": FIREBASE_TOKEN_2,
+        },
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_unregister_firebase_device():
+    response = client.delete(
+        "/notification/devices/" + FIREBASE_TOKEN_2,
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_get_devices():
+    response = client.get(
+        "/notification/devices/",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 200
+    json = response.json()
+    assert len(json) == 1
+    assert json[0]["firebase_device_token"] == FIREBASE_TOKEN_1
+
+
+def test_get_messages():
+    response = client.get(
+        "/notification/messages/" + FIREBASE_TOKEN_1,
+    )
+    assert response.status_code == 200
+
+
+def test_subscribe_to_topic():
+    response = client.post(
+        "/notification/topics/" + TOPIC_1 + "/subscribe",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+    response = client.post(
+        "/notification/topics/" + TOPIC_2 + "/subscribe",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+    response = client.post(
+        "/notification/topics/" + TOPIC_3 + "/subscribe",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_un_subscribe_to_topic():
+    response = client.post(
+        "/notification/topics/" + TOPIC_3 + "/unsubscribe",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_un_subscribe_to_topic_the_user_is_not_subscribed_to():
+    response = client.post(
+        "/notification/topics/" + TOPIC_4 + "/unsubscribe",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_get_topic():
+    response = client.get(
+        "/notification/topics/",
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == [TOPIC_1]
+
+
+def test_get_topic_identifier():
+    response = client.get(
+        "/notification/topics/" + TOPIC_1,
+        headers={
+            "Authorization": f"Bearer {admin_user_token}",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == [TOPIC_2]


### PR DESCRIPTION
### Description
The PR add tests for notifications. Due to the usage of Firebase messaging to send notifications, tests can not check notifications can be sent. Instead, they make sure our endpoints to register/unregister a device or subscribe to topics work.

Notifications were added:
 - when a loan is created, to notify the borrower
 - when a booking is accepted or refused to notify the applicant

To prevent anyone from subscribing to `bookingadmin` topic and then be notified of all booking requests, the notification is now send to all members of the room manager group. We way want to send the notification to just a few persons instead of the whole group.
