### PR TITLE
Use python 3.11 in leftover parts

### DIFF
--- a/.github/workflows/lintandformat.yml
+++ b/.github/workflows/lintandformat.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hyperion is the API of an open-source project launched by ÉCLAIR, the computer 
 
 The structure of this project is modular. Hyperion has a core that performs vital functions (authentication, database migration, authorization, etc). The other functions of Hyperion are realized in what we call modules. You can contribute to the project by adding modules if you wish.
 
-## Creating a virtual environment for Python 3.10.x
+## Creating a virtual environment for Python 3.11.x
 
 ### Windows
 
@@ -17,7 +17,7 @@ Create the virtual environment
 > You need to be in Hyperion main folder
 
 ```bash
-py -3.10 -m venv .venv
+py -3.11 -m venv .venv
 ```
 
 Activate it


### PR DESCRIPTION
### Description

This PR edits the few places in the repo to use python 3.11 for unit tests and when creating a new virtual environment. 
Currently, everything is a bit mismatched, the production docker image is on 3.11 while the ci/cd runs on 3.10 and the readme tells to use 3.11 under macos but 3.10 under windows.

### Checklist

- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the documentation, if necessary
