### PR TITLE
Fix notifications create_on

### DIFF
--- a/app/core/notification/models_notification.py
+++ b/app/core/notification/models_notification.py
@@ -36,7 +36,7 @@ class Message(Base):
     # We can plan a notification to be sent later, the frontend should not display it before the planned date
     delivery_datetime: Mapped[datetime] = mapped_column(TZDateTime, nullable=True)
     # Messages should be deleted after a certain time
-    expire_on: Mapped[date] = mapped_column(Date, nullable=False)
+    expire_on: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
 
 
 class FirebaseDevice(Base):

--- a/app/core/notification/schemas_notification.py
+++ b/app/core/notification/schemas_notification.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/app/core/notification/schemas_notification.py
+++ b/app/core/notification/schemas_notification.py
@@ -28,7 +28,7 @@ class Message(BaseModel):
         None,
         description="The date the notification should be shown",
     )
-    expire_on: date
+    expire_on: datetime
     model_config = ConfigDict(from_attributes=True)
 
 


### PR DESCRIPTION
### Description

Use datetime for expire_on instead of date.

This PR fixes the error `Datetimes provided to dates should have zero time - e.g. be exact dates [type=date_from_datetime_inexact, input_value=datetime.datetime(2024, 3...Paris' CET+1:00:00 STD>), input_type=datetime]`

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
