### PR TITLE
Make Hyperion installation easier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ unidecode==1.3.8
 uvicorn[standard]==0.23.2
 redis==5.0.2
 icalendar == 5.0.11
-psycopg2==2.9.9                     # PostgreSQL adapter for synchronous operations at startup (database initializations & migrations)
+psycopg2-binary==2.9.9                     # PostgreSQL adapter for synchronous operations at startup (database initializations & migrations)
 asyncpg==0.28.0                     # PostgreSQL adapter for asynchronous operations
 firebase-admin==6.4.0               # Firebase is used for push notification


### PR DESCRIPTION
Additional steps may be needed to install psycopg2 if we don't use the psycopg2-binary in the requirements.txt (see the documentation https://www.psycopg.org/docs/install.html).
