### PR TITLE
Valid filenames before get_file_from_data() security mitigations

### DIFF
--- a/app/modules/advert/endpoints_advert.py
+++ b/app/modules/advert/endpoints_advert.py
@@ -364,6 +364,7 @@ async def delete_advert(
 async def read_advert_image(
     advert_id: str,
     db: AsyncSession = Depends(get_db),
+    user: models_core.CoreUser = Depends(is_user_a_member),
 ):
     """
     Get the image of an advert

--- a/app/modules/advert/endpoints_advert.py
+++ b/app/modules/advert/endpoints_advert.py
@@ -363,12 +363,20 @@ async def delete_advert(
 )
 async def read_advert_image(
     advert_id: str,
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Get the image of an advert
 
     **The user must be authenticated to use this endpoint**
     """
+    advert = await cruds_advert.get_advert_by_id(db=db, advert_id=advert_id)
+    if advert is None:
+        raise HTTPException(
+            status_code=404,
+            detail="The advert does not exist",
+        )
+
     return get_file_from_data(
         default_asset="assets/images/default_advert.png",
         directory="adverts",

--- a/app/modules/campaign/endpoints_campaign.py
+++ b/app/modules/campaign/endpoints_campaign.py
@@ -873,6 +873,13 @@ async def read_campaigns_logo(
             detail="Access forbidden : you are not a poll member",
         )
 
+    campaign_list = await cruds_campaign.get_list_by_id(db=db, list_id=list_id)
+    if campaign_list is None:
+        raise HTTPException(
+            status_code=404,
+            detail="The list does not exist.",
+        )
+
     return get_file_from_data(
         directory="campaigns",
         filename=str(list_id),

--- a/app/modules/cinema/endpoints_cinema.py
+++ b/app/modules/cinema/endpoints_cinema.py
@@ -168,7 +168,15 @@ async def create_campaigns_logo(
 async def read_session_poster(
     session_id: str,
     user: models_core.CoreUser = Depends(is_user_a_member),
+    db: AsyncSession = Depends(get_db),
 ):
+    session = await cruds_cinema.get_session_by_id(db=db, session_id=session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=404,
+            detail="The session does not exist.",
+        )
+
     return get_file_from_data(
         default_asset="assets/images/default_movie.png",
         directory="cinemasessions",

--- a/app/modules/raffle/endpoints_raffle.py
+++ b/app/modules/raffle/endpoints_raffle.py
@@ -254,10 +254,14 @@ async def create_current_raffle_logo(
 async def read_raffle_logo(
     raffle_id: str,
     user: models_core.CoreUser = Depends(is_user_a_member),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Get the logo of a specific raffle.
     """
+    raffle = await cruds_raffle.get_raffle_by_id(raffle_id=raffle_id, db=db)
+    if not raffle:
+        raise HTTPException(status_code=404, detail="Raffle not found")
 
     return get_file_from_data(
         directory="raffle-pictures",

--- a/app/modules/raffle/endpoints_raffle.py
+++ b/app/modules/raffle/endpoints_raffle.py
@@ -800,10 +800,14 @@ async def create_prize_picture(
 async def read_prize_logo(
     prize_id: str,
     user: models_core.CoreUser = Depends(is_user_a_member),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Get the logo of a specific prize.
     """
+    prize = await cruds_raffle.get_prize_by_id(prize_id=prize_id, db=db)
+    if not prize:
+        raise HTTPException(status_code=404, detail="Prize not found")
 
     return get_file_from_data(
         directory="raffle-prize_picture",


### PR DESCRIPTION
### Description

- enforce valid filenames before get_file_from_data() in multiple endpoints in advert, campaign, cinema, raffle
- enforce user authentication in read_advert_image()

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary
