### PR TITLE
Fix OpenAPI specs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,3 @@
-# Hyperion & Titan version
-HYPERION_VERSION = "0.0.1"
-MINIMAL_TITAN_VERSION_CODE = 1
-
 # Authorization using JWT #
 ACCESS_TOKEN_SECRET_KEY = ""
 RSA_PRIVATE_PEM_STRING = ""

--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,6 @@
+# Hyperion & Titan version
+HYPERION_VERSION = "0.0.1"
+MINIMAL_TITAN_VERSION_CODE = 1
 
 # Authorization using JWT #
 ACCESS_TOKEN_SECRET_KEY = ""

--- a/app/app.py
+++ b/app/app.py
@@ -222,8 +222,7 @@ def use_route_path_as_operation_ids(app: FastAPI) -> None:
     for route in app.routes:
         if isinstance(route, APIRoute):
             # The operation_id should be unique.
-
-            # We currently never have more than one method per route
+            # It is possible to set multiple methods for the same endpoint method but it's not considered a good practice.
             method = "_".join(route.methods)
             route.operation_id = method.lower() + route.path.replace("/", "_")
 

--- a/app/app.py
+++ b/app/app.py
@@ -284,10 +284,6 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
     ):
         hyperion_error_logger.info("Redis client not configured")
 
-    if len(settings.DEPRECATED_SETTINGS) > 0:
-        for depreciation in settings.DEPRECATED_SETTINGS:
-            hyperion_error_logger.warning("DEPRECIATION NOTICE : " + depreciation)
-
     @app.middleware("http")
     async def logging_middleware(
         request: Request,

--- a/app/app.py
+++ b/app/app.py
@@ -211,10 +211,21 @@ def initialize_module_visibility(engine: Engine) -> None:
 
 
 def use_route_path_as_operation_ids(app: FastAPI) -> None:
-    """Simplify operation IDs so that generated API clients have simpler function names."""
+    """
+    Simplify operation IDs so that generated API clients have simpler function names.
+
+    Theses names may be used by API clients to generate function names.
+    The operation_id will have the format "method_path", like "get_users_me".
+
+    See https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/
+    """
     for route in app.routes:
         if isinstance(route, APIRoute):
-            route.operation_id = route.path
+            # The operation_id should be unique.
+
+            # We currently never have more than one method per route
+            method = "_".join(route.methods)
+            route.operation_id = method.lower() + route.path.replace("/", "_")
 
 
 # We wrap the application in a function to be able to pass the settings and drop_db parameters

--- a/app/app.py
+++ b/app/app.py
@@ -285,6 +285,10 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
     ):
         hyperion_error_logger.info("Redis client not configured")
 
+    if len(settings.DEPRECATED_SETTINGS) > 0:
+        for depreciation in settings.DEPRECATED_SETTINGS:
+            hyperion_error_logger.warning("DEPRECIATION NOTICE : " + depreciation)
+
     @app.middleware("http")
     async def logging_middleware(
         request: Request,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -203,12 +203,6 @@ class Settings(BaseSettings):
                 raise ValueError(
                     f".env AUTH_CLIENTS is invalid: {auth_client_name} is not an auth_client from app.utils.auth.providers",
                 ) from error
-            if auth_client_class.deprecated:
-                # The client is deprecated, we wont enable it
-                cls.DEPRECATED_SETTINGS.append(
-                    f"The auth client {client_id} {auth_client_name} is deprecated, it won't be enabled and may be removed in the future.",
-                )
-                continue
             # If the secret is empty, this mean the client is expected to use PKCE
             # We need to pass a None value to the auth_client_class
             if not secret:
@@ -221,8 +215,6 @@ class Settings(BaseSettings):
             )
 
         return clients
-
-    DEPRECATED_SETTINGS: list[str] = []
 
     #######################################
     #          Fields validation          #

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -203,6 +203,12 @@ class Settings(BaseSettings):
                 raise ValueError(
                     f".env AUTH_CLIENTS is invalid: {auth_client_name} is not an auth_client from app.utils.auth.providers",
                 ) from error
+            if auth_client_class.deprecated:
+                # The client is deprecated, we wont enable it
+                cls.DEPRECATED_SETTINGS.append(
+                    f"The auth client {client_id} {auth_client_name} is deprecated, it won't be enabled and may be removed in the future.",
+                )
+                continue
             # If the secret is empty, this mean the client is expected to use PKCE
             # We need to pass a None value to the auth_client_class
             if not secret:
@@ -215,6 +221,8 @@ class Settings(BaseSettings):
             )
 
         return clients
+
+    DEPRECATED_SETTINGS: list[str] = []
 
     #######################################
     #          Fields validation          #

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -99,12 +99,13 @@ class Settings(BaseSettings):
 
     # By default, only production's records are logged
     LOG_DEBUG_MESSAGES: bool | None
+
     # Hyperion follows Semantic Versioning
     # https://semver.org/
-    HYPERION_VERSION: str = "1.0.0"  # This value should never be modified by hand. See [Hyperion release] documentation
+    HYPERION_VERSION: str = "2.4.0"
     MINIMAL_TITAN_VERSION_CODE: int = 113
-    # Depreciated, minimal_titan_version_code should be used
-    MINIMAL_TITAN_VERSION: str = "0.0.1"
+
+    MINIMAL_TITAN_VERSION: str = "0.0.1"  # deprecated, use MINIMAL_TITAN_VERSION_CODE
 
     # Origins for the CORS middleware. `["http://localhost"]` can be used for development.
     # See https://fastapi.tiangolo.com/tutorial/cors/

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -20,9 +20,9 @@ It is important to use enough rounds while accounting for the hash computation t
 """
 
 oauth2_scheme = OAuth2AuthorizationCodeBearer(
-    authorizationUrl="auth/authorize",
-    tokenUrl="auth/token",
-    scheme_name="Authorization Code authentication",
+    authorizationUrl="/auth/authorize",
+    tokenUrl="/auth/token",
+    scheme_name="AuthorizationCodeAuthentication",
 )
 """
 To generate JWT access tokens, we use a *FastAPI* OAuth2PasswordBearer object.

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -23,6 +23,7 @@ oauth2_scheme = OAuth2AuthorizationCodeBearer(
     authorizationUrl="/auth/authorize",
     tokenUrl="/auth/token",
     scheme_name="AuthorizationCodeAuthentication",
+    scopes={"API": "Access Hyperion endpoints"},
 )
 """
 To generate JWT access tokens, we use a *FastAPI* OAuth2PasswordBearer object.

--- a/app/modules/calendar/endpoints_calendar.py
+++ b/app/modules/calendar/endpoints_calendar.py
@@ -102,7 +102,7 @@ async def get_event_by_id(
 
 
 @module.router.get(
-    "calendar/events/{event_id}/applicant",
+    "/calendar/events/{event_id}/applicant",
     response_model=schemas_calendar.EventApplicant,
     status_code=200,
 )

--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -43,10 +43,6 @@ class BaseAuthClient:
     # By setting this parameter to True, the userinfo will be added to the id_token.
     return_userinfo_in_id_token: bool = False
 
-    # Marking a client as deprecated will prevent it from being used.
-    # A warning will be displayed in the logs on Hyperion startup.
-    deprecated: bool = False
-
     def get_userinfo(self, user: models_core.CoreUser) -> dict[str, Any]:
         """
         Return information about the user in a format understandable by the client.
@@ -102,22 +98,20 @@ class AppAuthClient(BaseAuthClient):
     allowed_groups: list[GroupType] | None = None
 
 
-class PostmanAuthClient(BaseAuthClient):
-    """
-    An auth client for Postman
-
-    Deprecated: use APIToolAuthClient
-    """
-
-    deprecated: bool = True
-
-
 class APIToolAuthClient(BaseAuthClient):
     """
     An auth client for API development tools
     """
 
     allowed_scopes: set[ScopeType | str] = {ScopeType.API}
+
+
+class PostmanAuthClient(APIToolAuthClient):
+    """
+    An auth client for Postman
+
+    Deprecated: use APIToolAuthClient
+    """
 
 
 class NextcloudAuthClient(BaseAuthClient):

--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -110,11 +110,13 @@ class PostmanAuthClient(BaseAuthClient):
     """
 
     deprecated: bool = True
+
+
+class APIToolAuthClient(BaseAuthClient):
+    """
+    An auth client for API development tools
     """
 
-    # Set of scopes the auth client is authorized to grant when issuing an access token.
-    # See app.types.scopes_type.ScopeType for possible values
-    # WARNING: to be able to use openid connect, `ScopeType.openid` should always be allowed
     allowed_scopes: set[ScopeType | str] = {ScopeType.API}
 
 

--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -43,6 +43,10 @@ class BaseAuthClient:
     # By setting this parameter to True, the userinfo will be added to the id_token.
     return_userinfo_in_id_token: bool = False
 
+    # Marking a client as deprecated will prevent it from being used.
+    # A warning will be displayed in the logs on Hyperion startup.
+    deprecated: bool = False
+
     def get_userinfo(self, user: models_core.CoreUser) -> dict[str, Any]:
         """
         Return information about the user in a format understandable by the client.
@@ -101,6 +105,11 @@ class AppAuthClient(BaseAuthClient):
 class PostmanAuthClient(BaseAuthClient):
     """
     An auth client for Postman
+
+    Deprecated: use APIToolAuthClient
+    """
+
+    deprecated: bool = True
     """
 
     # Set of scopes the auth client is authorized to grant when issuing an access token.

--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -106,14 +106,6 @@ class APIToolAuthClient(BaseAuthClient):
     allowed_scopes: set[ScopeType | str] = {ScopeType.API}
 
 
-class PostmanAuthClient(APIToolAuthClient):
-    """
-    An auth client for Postman
-
-    Deprecated: use APIToolAuthClient
-    """
-
-
 class NextcloudAuthClient(BaseAuthClient):
     # Set of scopes the auth client is authorized to grant when issuing an access token.
     # See app.types.scopes_type.ScopeType for possible values


### PR DESCRIPTION
### Description

This PR fixes OpenAPI specs, with the aim to be fully compatible with several API clients like Hoppscotch.

This includes:
- the fix of an invalid endpoint, which should always start with `/` (see https://learn.openapis.org/specification/paths.html#the-endpoints-list)
- the fix of the invalid security scheme_name, which should match `^[a-zA-Z0-9\.\-_]+$` (see https://spec.openapis.org/oas/latest.html#fixed-fields-5)
- automatically set operationId to the path for each route
- add name and version to the OpenAPI specifications
- add `HYPERION_VERSION` and `MINIMAL_TITAN_VERSION_CODE` to .env

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the documentation, if necessary

### Breaking change
Remove `PostmanAuthClient`