### PR TITLE
Bump fastapi, ruff and httpx

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -281,7 +281,6 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
             port = request.client.port
             client_address = f"{ip_address}:{port}"
         else:
-            ip_address = "0.0.0.0"  # In case of a test (see https://github.com/encode/starlette/pull/2377)
             client_address = "unknown"
 
         settings: Settings = app.dependency_overrides.get(get_settings, get_settings)()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ aiosqlite==0.19.0
 pytest==8.0.2
 pytest-asyncio==0.21.1
 pytest-mock==3.12.0
-httpx==0.26.0 # needed for tests as a replacement of requests in TestClient
-ruff==0.3.0 
+httpx==0.27.0 # needed for tests as a replacement of requests in TestClient
+ruff==0.3.5 
 types-aiofiles==23.2.0.20240106
 types-requests==2.31.0.20231231
 types-redis==4.6.0.20240218

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest==8.0.2
 pytest-asyncio==0.21.1
 pytest-mock==3.12.0
 httpx==0.27.0 # needed for tests as a replacement of requests in TestClient
-ruff==0.3.5 
+ruff==0.3.7
 types-aiofiles==23.2.0.20240106
 types-requests==2.31.0.20231231
 types-redis==4.6.0.20240218

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==23.2.1                    # Asynchronous file manipulation
 alembic==1.13.1                      # database migrations
-fastapi==0.109.2
+fastapi==0.110.1
 Jinja2==3.1.3                       # template engine for html files
 bcrypt==4.1.2                       # password hashing
 pydantic-settings==2.2.1


### PR DESCRIPTION
### Description

This PR bumps 
- `fastapi` to `110.1`
- `ruff` to `0.3.7`
- `httpx` to `0.27.0`
And removes the test workaround because we now use the latest version of Starlette that reverted `"Turn scope["client"] to None on TestClient`
### Checklist

- [x] All tests passing
