### PR TITLE
Add CoreData to store values in an unique row

### DIFF
--- a/app/core/cruds_core.py
+++ b/app/core/cruds_core.py
@@ -92,3 +92,50 @@ async def delete_module_visibility(
         ),
     )
     await db.commit()
+
+
+async def get_core_data_crud(
+    schema: str,
+    db: AsyncSession,
+) -> models_core.CoreData | None:
+    """
+    Get the core data model from the database.
+
+    To manipulate core data, prefer using the `get_core_data` and `set_core_data` utils.
+    """
+    result = await db.execute(
+        select(models_core.CoreData).where(
+            models_core.CoreData.schema == schema,
+        ),
+    )
+    return result.scalars().first()
+
+
+async def add_core_data_crud(
+    core_data: models_core.CoreData,
+    db: AsyncSession,
+) -> models_core.CoreData:
+    """
+    Add a core data model in database.
+
+    To manipulate core data, prefer using the `get_core_data` and `set_core_data` utils.
+    """
+    db.add(core_data)
+    try:
+        await db.commit()
+        return core_data
+    except IntegrityError as error:
+        await db.rollback()
+        raise ValueError(error)
+
+
+async def delete_core_data_crud(
+    schema: str,
+    db: AsyncSession,
+):
+    await db.execute(
+        delete(models_core.CoreData).where(
+            models_core.CoreData.schema == schema,
+        ),
+    )
+    await db.commit()

--- a/app/core/models_core.py
+++ b/app/core/models_core.py
@@ -105,6 +105,22 @@ class CoreGroup(Base):
     )
 
 
+class CoreData(Base):
+    """
+    A table to store arbitrary data.
+
+     - schema: the name of the schema allowing to deserialize the data.
+     - data: the json data.
+
+    Use `get_core_data` and `set_core_data` utils to interact with this table.
+    """
+
+    __tablename__ = "core_data"
+
+    schema: Mapped[str] = mapped_column(String, primary_key=True)
+    data: Mapped[str] = mapped_column(String, nullable=False)
+
+
 class ModuleVisibility(Base):
     __tablename__ = "module_visibility"
 

--- a/app/types/core_data.py
+++ b/app/types/core_data.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel
+
+
+class BaseCoreData(BaseModel):
+    """
+    A base model for core data class.
+
+    Core data functionalities should be used when you need to store an unique row in the database.
+    A typical use case is to store settings or configuration state for a module. If you need multiple rows, use a dedicated table.
+
+    To use this class, you need to subclass it and define the fields you want to store in the database.
+    Exemple:
+    ```python
+    class ExempleCoreData(BaseCoreData):
+        name: str = "default"
+        age: int = 18
+    ```
+
+    Then, you can use the `get_core_data` and `set_core_data` utils to interact with the database.
+    ```python
+    # Note: we pass the class object directly, and not an instance: `ExempleCoreData`
+    core_data: ExempleCoreData = await get_core_data(ExempleCoreData)
+
+    # Note: we pass an instance of the class, containing the data we want to store: `new_exemple_core_data`
+    new_exemple_core_data: ExempleCoreData = ExempleCoreData(name="Fabristpp", age=42)
+    await set_core_data(new_exemple_core_data)
+    ```
+
+    We you set core data, the content of the instance will be serialized to JSON and stored in the database,
+    associated with the key corresponding to the name of your class.
+    NOTE: the name of your class should thus be unique. We suggest to use the module name as prefix to avoid conflicts: ModuleCoreData, or ModuleMyDataNameCoreData.
+
+    When you get core data, the JSON data will be deserialized using the class.
+
+    When getting the data, if it does not exist in the database, a new instance of the class will be created.
+    If you want to set default values, you can set them in the class definition:
+    ```python
+    class DefaultValueCoreData(BaseCoreData):
+        name: str = "Default name"
+    ```
+    If you prefer a CoreDataNotFoundException to be raised when the data is not found in the database, just don't set default parameters.
+    ```python
+    class DefaultValueCoreData(BaseCoreData):
+        name: str
+    ```
+
+    NOTE: making modifications to a CoreData class will usually require a migration to update the data in the database.
+    """

--- a/app/types/exceptions.py
+++ b/app/types/exceptions.py
@@ -1,0 +1,2 @@
+class CoreDataNotFoundException(Exception):
+    pass

--- a/app/utils/tools.py
+++ b/app/utils/tools.py
@@ -19,9 +19,9 @@ from app.core.groups import cruds_groups
 from app.core.groups.groups_type import GroupType
 from app.core.models_core import CoreUser
 from app.core.users import cruds_users
+from app.types import core_data
 from app.types.content_type import ContentType
-from app.utils.types import core_data
-from app.utils.types.exceptions import CoreDataNotFoundException
+from app.types.exceptions import CoreDataNotFoundException
 
 hyperion_error_logger = logging.getLogger("hyperion.error")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ import pytest_asyncio
 from fastapi import HTTPException, UploadFile
 
 from app.core import models_core
+from app.types.core_data import BaseCoreData
+from app.types.exceptions import CoreDataNotFoundException
 from app.utils.tools import (
     delete_file_from_data,
     get_core_data,
@@ -17,8 +19,6 @@ from app.utils.tools import (
     save_pdf_first_page_as_image,
     set_core_data,
 )
-from app.utils.types.core_data import BaseCoreData
-from app.utils.types.exceptions import CoreDataNotFoundException
 from tests.commons import (
     TestingSessionLocal,
     add_object_to_db,


### PR DESCRIPTION
### Description

We often need to store a unique row with a few values:
 - the status of the campaign
 - if some module is enabled
 - the state of the amap service...

This PR add logic to store a few values per module in a global table: CoreData. The data will be serialized into JSON using a custom Pydantic schema.

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the documentation, if necessary
