### PR TITLE
Push to registry only on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,9 @@
 name: Build and Publish Hyperion Docker Images
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "main"
-    tags:
-      - "v*"
+  release:
+    types:
+      - "published"
 
 jobs:
   docker:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_REGISTRY_IDENTIFER }}/hyperion
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Build and Publish Hyperion Docker Images
 on:
   workflow_dispatch:
-  release:
-    types:
-      - "published"
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   docker:


### PR DESCRIPTION
We are currently pushing on the registry at each commit on main.

We only need to push to the registry when there is a new release.
