### PR TITLE
enhancement: Use `uv` instead of `pip` during ci tests

### DIFF
--- a/.github/workflows/lintandformat.yml
+++ b/.github/workflows/lintandformat.yml
@@ -17,15 +17,22 @@ jobs:
       # Setup Python (faster than using Python container)
       - name: Setup Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: "3.11"
-          cache: "pip"
+
+      - name: Cache uv folder
+        id: cache-uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-uv-${{ hashFiles('requirements-common.txt', 'requirements-dev.txt') }}
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-          pip install "fastapi[all]"
+        run: uv pip install --system -r requirements-dev.txt
 
       - name: Cache .ruff_cache folder
         id: ruff_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,15 +38,22 @@ jobs:
       # Setup Python (faster than using Python container)
       - name: Setup Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: "3.11"
-          cache: "pip"
+
+      - name: Cache uv folder
+        id: cache-uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-uv-${{ hashFiles('requirements-common.txt', 'requirements-dev.txt') }}
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-          pip install "fastapi[all]"
+        run: uv pip install --system -r requirements-dev.txt
 
       - name: Cache .pytest_cache folder
         id: pytest_cache


### PR DESCRIPTION
This PR makes the Hyperion repo use `uv` during ci tests. `uv` is a replacement for `pip` written in rust.
Ideally, ci tests should now be quicker ! No expected breakage from this PR since we don't use special pip functionalities (see https://astral.sh/blog/uv)

We'll use the official setup python gh action with uv when it will be merged or implemented (see https://github.com/actions/setup-python/pull/818).