### PR TITLE
Use postgresql for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@
 #   This dotenv file and its values should NEVER be used in PRODUCTION!   #
 ###########################################################################
 
-SQLITE_DB = "" # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
+SQLITE_DB = "test.db" # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
 
 # Authorization using JWT #
 ACCESS_TOKEN_SECRET_KEY="YWZOHliiI53lJMJc5BI_WbGbA4GF2T7Wbt1airIhOXEa3c021c4-1c55-4182-b141-7778bcc8fac4" # Note: modifing this token requires to update the common `test_check_settings_mocking` test

--- a/.env.test
+++ b/.env.test
@@ -48,7 +48,7 @@ REDIS_LIMIT = 5
 REDIS_WINDOW = 60
 
 # PostgreSQL configuration # Will be used if tests are run with postgresql (should be the case because postgre is used in production)
-POSTGRES_HOST = "postgres" 
+POSTGRES_HOST = "localhost" 
 POSTGRES_USER = "hyperion"
 POSTGRES_PASSWORD = "somerealpassword"
 POSTGRES_DB = "hyperion"

--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@
 #   This dotenv file and its values should NEVER be used in PRODUCTION!   #
 ###########################################################################
 
-SQLITE_DB = "test.db" # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
+SQLITE_DB = "" # If set, the application use a SQLite database instead of PostgreSQL, for testing or development purposes (should not be used if possible)
 
 # Authorization using JWT #
 ACCESS_TOKEN_SECRET_KEY="YWZOHliiI53lJMJc5BI_WbGbA4GF2T7Wbt1airIhOXEa3c021c4-1c55-4182-b141-7778bcc8fac4" # Note: modifing this token requires to update the common `test_check_settings_mocking` test
@@ -48,7 +48,7 @@ REDIS_LIMIT = 5
 REDIS_WINDOW = 60
 
 # PostgreSQL configuration # Will be used if tests are run with postgresql (should be the case because postgre is used in production)
-POSTGRES_HOST = "localhost" 
+POSTGRES_HOST = "postgres" 
 POSTGRES_USER = "hyperion"
 POSTGRES_PASSWORD = "somerealpassword"
 POSTGRES_DB = "hyperion"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,23 @@ jobs:
         ports:
           # Maps port 6379 on service container to the host
           - 6379:6379
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: "somerealpassword"
+          POSTGRES_USER: "hyperion"
+          POSTGRES_DB: "hyperion"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
 
     steps:
       - name: Check out the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,14 @@ jobs:
         with:
           path: .pytest_cache
           key: pytest_cache-${{ github.head_ref }}
+      
+      - name: Run migration unit tests with SQLite
+        run: python -m pytest tests/test_migrations.py
 
-      - name: Run unit tests
+      - name: Run unit tests with Postgresql
         run: python -m pytest --cov
+        env:
+          SQLITE_DB: ""
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ logs/
 
 # Pytest-cov
 .coverage
-
-# Migration tests
-test_migration.db
-test_migration.db-journal

--- a/migrations/versions/0-6-init.py
+++ b/migrations/versions/0-6-init.py
@@ -2,7 +2,7 @@
 
 Revision ID: 17b92dc4b50d
 Revises:
-Create Date: 2024-04-12 18:19:12.439926
+Create Date: 2024-05-26 16:25:22.390935
 
 """
 
@@ -929,6 +929,74 @@ def downgrade() -> None:
     op.drop_table("amap_delivery")
     op.drop_index(op.f("ix_advert_advertisers_id"), table_name="advert_advertisers")
     op.drop_table("advert_advertisers")
+    sa.Enum(
+        "Autre",
+        "Adoma",
+        "Exte",
+        "T1",
+        "T2",
+        "T3",
+        "T4",
+        "T56",
+        "U1",
+        "U2",
+        "U3",
+        "U4",
+        "U56",
+        "V1",
+        "V2",
+        "V3",
+        "V45",
+        "V6",
+        "X1",
+        "X2",
+        "X3",
+        "X4",
+        "X5",
+        "X6",
+        name="floorstype",
+    ).drop(op.get_bind())
+    sa.Enum(
+        "cinema",
+        "advert",
+        "bookingadmin",
+        "amap",
+        "booking",
+        "event",
+        "loan",
+        "raffle",
+        "vote",
+        name="topic",
+    ).drop(op.get_bind())
+    sa.Enum(
+        "eventAE",
+        "eventUSE",
+        "independentAssociation",
+        "happyHour",
+        "direction",
+        "nightParty",
+        "other",
+        name="calendareventtype",
+    ).drop(op.get_bind())
+    sa.Enum(
+        "comity",
+        "section_ae",
+        "club_ae",
+        "section_use",
+        "club_use",
+        "association_independant",
+        name="kinds",
+    ).drop(op.get_bind())
+    sa.Enum(
+        "waiting",
+        "open",
+        "closed",
+        "counting",
+        "published",
+        name="statustype",
+    ).drop(op.get_bind())
+    sa.Enum("midi", "soir", name="amapslottype").drop(op.get_bind())
+    sa.Enum("creation", "open", "lock", name="rafflestatustype").drop(op.get_bind())
     # ### end Alembic commands ###
 
 

--- a/migrations/versions/8-recommendation_primary_key.py
+++ b/migrations/versions/8-recommendation_primary_key.py
@@ -6,6 +6,7 @@ Create Date: 2024-04-21 02:08:19.548067
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import sqlalchemy as sa
 from alembic import op
@@ -61,4 +62,10 @@ def test_upgrade(
         sa.text("SELECT id from recommendation"),
     ).fetchall()
 
-    assert ("66c363bc-c71f-4eae-8376-c37712a312f6",) in rows
+    assert len(rows) > 0
+
+    if isinstance(rows[0][0], UUID):
+        assert (UUID("66c363bc-c71f-4eae-8376-c37712a312f6"),) in rows
+    else:
+        # SQLite does not support UUID and will use strings
+        assert ("66c363bc-c71f-4eae-8376-c37712a312f6",) in rows

--- a/migrations/versions/9-external_users.py
+++ b/migrations/versions/9-external_users.py
@@ -78,6 +78,11 @@ def downgrade() -> None:
     op.drop_column("core_user_unconfirmed", "external")
     op.drop_column("core_user", "external")
 
+    core_user = sa.sql.table("core_user", sa.Column("floor"))
+    op.execute(
+        core_user.update().where(core_user.c.floor.is_(None)).values(floor="Autre"),
+    )
+
     with op.batch_alter_table("core_user") as batch_op:
         batch_op.alter_column(
             "floor",
@@ -108,6 +113,7 @@ def downgrade() -> None:
                 "X6",
                 name="floorstype",
             ),
+            # We make this column non nullable, we must provide a default value
             nullable=False,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,13 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+filterwarnings = [
+    "error",
+    # We don't know how to fix the warning:
+    # `ResourceWarning: connection <psycopg.Connection [IDLE] (host=... user=... database=...) at 0x1166bf310> was deleted while still open. Please use 'with' or '.close()' to close the connection`
+    # It only happen when running tests with Postgresql
+    "ignore:connection <.*> was deleted while still open.:ResourceWarning",
+]
 
 [tool.coverage.run]
 source_pkgs = ["app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-filterwarnings = "error"
 
 [tool.coverage.run]
 source_pkgs = ["app"]

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -43,7 +43,13 @@ else:
     SQLALCHEMY_DATABASE_URL_SYNC = f"postgresql+psycopg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
 
 
-engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True, poolclass=NullPool)
+engine = create_async_engine(
+    SQLALCHEMY_DATABASE_URL,
+    echo=True,
+    # We need to use NullPool to run tests with Postgresql
+    # See https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops
+    poolclass=NullPool,
+)
 
 TestingSessionLocal = async_sessionmaker(
     engine,

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 import redis
 from fastapi import Depends
 from fastapi.testclient import TestClient
+from sqlalchemy import NullPool
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -41,7 +42,7 @@ else:
     SQLALCHEMY_DATABASE_URL = f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
 
 
-engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True)
+engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True, poolclass=NullPool)
 
 TestingSessionLocal = async_sessionmaker(
     engine,
@@ -97,9 +98,6 @@ test_app.dependency_overrides[get_redis_client] = override_get_redis_client
 
 
 client = TestClient(test_app)  # Create a client to execute tests
-
-with client:  # That syntax trigger the lifespan defined in main.py
-    pass
 
 
 async def create_user_with_groups(

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -5,19 +5,17 @@ from functools import lru_cache
 
 import redis
 from fastapi import Depends
-from fastapi.testclient import TestClient
 from sqlalchemy import NullPool
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.app import get_application
 from app.core import models_core, security
 from app.core.auth import schemas_auth
 from app.core.config import Settings
 from app.core.groups import cruds_groups
 from app.core.groups.groups_type import GroupType
 from app.core.users import cruds_users
-from app.dependencies import get_db, get_redis_client, get_settings
+from app.dependencies import get_settings
 from app.types.floors_type import FloorsType
 from app.types.sqlalchemy import Base
 from app.utils.redis import connect, disconnect
@@ -32,7 +30,6 @@ def override_get_settings() -> Settings:
 
 settings = override_get_settings()
 
-test_app = get_application(settings=settings, drop_db=True)  # Create the test's app
 
 # Connect to the test's database
 if settings.SQLITE_DB:
@@ -97,14 +94,6 @@ def change_redis_client_status(activated: bool) -> None:
             redis_client.flushdb()
             disconnect(redis_client)
         redis_client = False
-
-
-test_app.dependency_overrides[get_db] = override_get_db
-test_app.dependency_overrides[get_settings] = override_get_settings
-test_app.dependency_overrides[get_redis_client] = override_get_redis_client
-
-
-client = TestClient(test_app)  # Create a client to execute tests
 
 
 async def create_user_with_groups(

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -34,14 +34,13 @@ settings = override_get_settings()
 
 test_app = get_application(settings=settings, drop_db=True)  # Create the test's app
 
+# Connect to the test's database
 if settings.SQLITE_DB:
-    SQLALCHEMY_DATABASE_URL = (
-        f"sqlite+aiosqlite:///./{settings.SQLITE_DB}"  # Connect to the test's database
-    )
+    SQLALCHEMY_DATABASE_URL = f"sqlite+aiosqlite:///./{settings.SQLITE_DB}"
     SQLALCHEMY_DATABASE_URL_SYNC = f"sqlite:///./{settings.SQLITE_DB}"
 else:
     SQLALCHEMY_DATABASE_URL = f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
-    SQLALCHEMY_DATABASE_URL_SYNC = f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
+    SQLALCHEMY_DATABASE_URL_SYNC = f"postgresql+psycopg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
 
 
 engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True, poolclass=NullPool)

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -38,8 +38,10 @@ if settings.SQLITE_DB:
     SQLALCHEMY_DATABASE_URL = (
         f"sqlite+aiosqlite:///./{settings.SQLITE_DB}"  # Connect to the test's database
     )
+    SQLALCHEMY_DATABASE_URL_SYNC = f"sqlite:///./{settings.SQLITE_DB}"
 else:
     SQLALCHEMY_DATABASE_URL = f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
+    SQLALCHEMY_DATABASE_URL_SYNC = f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
 
 
 engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=True, poolclass=NullPool)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.app import get_application
+from app.dependencies import get_db, get_redis_client, get_settings
+from tests.commons import (
+    override_get_db,
+    override_get_redis_client,
+    override_get_settings,
+    settings,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def client() -> TestClient:
+    test_app = get_application(settings=settings, drop_db=True)  # Create the test's app
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[get_settings] = override_get_settings
+    test_app.dependency_overrides[get_redis_client] = override_get_redis_client
+
+    return TestClient(test_app)  # Create a client to execute tests

--- a/tests/test_PH.py
+++ b/tests/test_PH.py
@@ -3,13 +3,13 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.ph import models_ph
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -25,7 +25,7 @@ paper2: models_ph.Paper
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     global ph_user_ph
     ph_user_ph = await create_user_with_groups([GroupType.ph])
 
@@ -55,7 +55,7 @@ async def init_objects():
     await add_object_to_db(paper2)
 
 
-def test_create_paper():
+def test_create_paper(client: TestClient) -> None:
     response = client.post(
         "/ph/",
         json={
@@ -68,7 +68,7 @@ def test_create_paper():
     assert response.status_code == 201
 
 
-def test_get_papers():
+def test_get_papers(client: TestClient) -> None:
     response = client.get(
         "/ph/",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -81,7 +81,7 @@ def test_get_papers():
     ]
 
 
-def test_get_papers_admin():
+def test_get_papers_admin(client: TestClient) -> None:
     response = client.get(
         "/ph/admin",
         headers={"Authorization": f"Bearer {token_ph}"},
@@ -92,7 +92,7 @@ def test_get_papers_admin():
     assert str(paper2.id) in [response_paper["id"] for response_paper in response_json]
 
 
-def test_create_paper_pdf_and_cover():
+def test_create_paper_pdf_and_cover(client: TestClient) -> None:
     with Path("assets/pdf/default_ph.pdf").open("rb") as pdf:
         response = client.post(
             f"/ph/{paper.id}/pdf",
@@ -105,7 +105,7 @@ def test_create_paper_pdf_and_cover():
     assert Path(f"data/ph/cover/{paper.id}.jpg").is_file()
 
 
-def test_get_paper_pdf():
+def test_get_paper_pdf(client: TestClient) -> None:
     response = client.get(
         f"/ph/{paper.id}/pdf",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -113,7 +113,7 @@ def test_get_paper_pdf():
     assert response.status_code == 200
 
 
-def test_get_cover():
+def test_get_cover(client: TestClient) -> None:
     response = client.get(
         f"/ph/{paper.id}/cover",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -121,7 +121,7 @@ def test_get_cover():
     assert response.status_code == 200
 
 
-def test_update_paper():
+def test_update_paper(client: TestClient) -> None:
     response = client.patch(
         f"/ph/{paper.id}",
         json={
@@ -133,7 +133,7 @@ def test_update_paper():
     assert response.status_code == 204
 
 
-def test_delete_paper():
+def test_delete_paper(client: TestClient) -> None:
     with Path("assets/pdf/default_PDF.pdf").open("rb") as pdf:
         client.post(
             f"/ph/{paper.id}/pdf",

--- a/tests/test_advert.py
+++ b/tests/test_advert.py
@@ -3,13 +3,13 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.advert import models_advert
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -66,7 +66,7 @@ async def init_objects() -> None:
     await add_object_to_db(advert)
 
 
-def test_get_adverts() -> None:
+def test_get_adverts(client: TestClient) -> None:
     response = client.get(
         "/advert/adverts",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -74,7 +74,7 @@ def test_get_adverts() -> None:
     assert response.status_code == 200
 
 
-def test_get_advert_by_id() -> None:
+def test_get_advert_by_id(client: TestClient) -> None:
     response = client.get(
         f"/advert/adverts/{advert.id}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -82,7 +82,7 @@ def test_get_advert_by_id() -> None:
     assert response.status_code == 200
 
 
-def test_get_advert_by_advertisers() -> None:
+def test_get_advert_by_advertisers(client: TestClient) -> None:
     response = client.get(
         f"/advert/adverts?advertisers={advertiser.id}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -90,7 +90,7 @@ def test_get_advert_by_advertisers() -> None:
     assert response.status_code == 200
 
 
-def test_create_advert() -> None:
+def test_create_advert(client: TestClient) -> None:
     response = client.post(
         "/advert/adverts",
         json={
@@ -104,7 +104,7 @@ def test_create_advert() -> None:
     assert response.status_code == 201
 
 
-def test_create_picture() -> None:
+def test_create_picture(client: TestClient) -> None:
     with Path("assets/images/default_advert.png").open("rb") as image:
         response = client.post(
             f"/advert/adverts/{advert.id}/picture",
@@ -115,7 +115,7 @@ def test_create_picture() -> None:
     assert response.status_code == 201
 
 
-def test_get_picture() -> None:
+def test_get_picture(client: TestClient) -> None:
     response = client.get(
         f"/advert/adverts/{advert.id}/picture",
         headers={"Authorization": f"Bearer {token_advertiser}"},
@@ -124,7 +124,7 @@ def test_get_picture() -> None:
     assert response.status_code == 200
 
 
-def test_edit_advert() -> None:
+def test_edit_advert(client: TestClient) -> None:
     response = client.patch(
         f"/advert/adverts/{advert.id}",
         json={"content": "Advert Content Edited"},
@@ -133,7 +133,7 @@ def test_edit_advert() -> None:
     assert response.status_code == 204
 
 
-def test_delete_advert() -> None:
+def test_delete_advert(client: TestClient) -> None:
     response = client.delete(
         f"/advert/adverts/{advert.id}",
         headers={"Authorization": f"Bearer {token_advertiser}"},
@@ -141,7 +141,7 @@ def test_delete_advert() -> None:
     assert response.status_code == 204
 
 
-def test_get_advertisers() -> None:
+def test_get_advertisers(client: TestClient) -> None:
     response = client.get(
         "/advert/advertisers",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -149,7 +149,7 @@ def test_get_advertisers() -> None:
     assert response.status_code == 200
 
 
-def test_get_my_advertisers() -> None:
+def test_get_my_advertisers(client: TestClient) -> None:
     response = client.get(
         "/advert/me/advertisers",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -157,7 +157,7 @@ def test_get_my_advertisers() -> None:
     assert response.status_code == 200
 
 
-def test_create_advertiser() -> None:
+def test_create_advertiser(client: TestClient) -> None:
     response = client.post(
         "/advert/advertisers",
         json={"name": "Advert2", "group_manager_id": advertiser.group_manager_id},
@@ -166,7 +166,7 @@ def test_create_advertiser() -> None:
     assert response.status_code == 201
 
 
-def test_edit_advertiser() -> None:
+def test_edit_advertiser(client: TestClient) -> None:
     response = client.patch(
         f"/advert/advertisers/{advertiser.id}",
         json={"name": "AdvertiserEdited"},
@@ -175,7 +175,7 @@ def test_edit_advertiser() -> None:
     assert response.status_code == 204
 
 
-def test_delete_advertiser() -> None:
+def test_delete_advertiser(client: TestClient) -> None:
     response = client.delete(
         f"/advert/advertisers/{advertiser.id}",
         headers={"Authorization": f"Bearer {token_admin}"},

--- a/tests/test_amap.py
+++ b/tests/test_amap.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
@@ -10,7 +11,6 @@ from app.modules.amap.types_amap import AmapSlotType, DeliveryStatusType
 from tests.commons import (
     add_object_to_db,
     change_redis_client_status,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -104,7 +104,7 @@ async def init_objects() -> None:
     await add_object_to_db(cash)
 
 
-def test_get_products() -> None:
+def test_get_products(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.get(
@@ -114,7 +114,7 @@ def test_get_products() -> None:
     assert response.status_code == 200
 
 
-def test_create_product() -> None:
+def test_create_product(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.post(
@@ -125,7 +125,7 @@ def test_create_product() -> None:
     assert response.status_code == 201
 
 
-def test_get_product_by_id() -> None:
+def test_get_product_by_id(client: TestClient) -> None:
     # The user doesn't need to be part of group amap to get a product
     student_token = create_api_access_token(student_user)
 
@@ -136,7 +136,7 @@ def test_get_product_by_id() -> None:
     assert response.status_code == 200
 
 
-def test_edit_product() -> None:
+def test_edit_product(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.patch(
@@ -147,7 +147,7 @@ def test_edit_product() -> None:
     assert response.status_code == 204
 
 
-def test_delete_product() -> None:
+def test_delete_product(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.delete(
@@ -157,7 +157,7 @@ def test_delete_product() -> None:
     assert response.status_code == 204
 
 
-def test_get_deliveries() -> None:
+def test_get_deliveries(client: TestClient) -> None:
     # The user don't need to be part of group amap to get a product
     student_token = create_api_access_token(student_user)
 
@@ -168,7 +168,7 @@ def test_get_deliveries() -> None:
     assert response.status_code == 200
 
 
-def test_create_delivery() -> None:
+def test_create_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.post(
@@ -183,7 +183,7 @@ def test_create_delivery() -> None:
     assert response.status_code == 201
 
 
-def test_delete_delivery() -> None:
+def test_delete_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.delete(
@@ -193,7 +193,7 @@ def test_delete_delivery() -> None:
     assert response.status_code == 204
 
 
-def test_edit_delivery() -> None:
+def test_edit_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.patch(
@@ -204,7 +204,7 @@ def test_edit_delivery() -> None:
     assert response.status_code == 204
 
 
-def test_add_product_to_delivery() -> None:
+def test_add_product_to_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.post(
@@ -215,7 +215,7 @@ def test_add_product_to_delivery() -> None:
     assert response.status_code == 201
 
 
-def test_remove_product_from_delivery() -> None:
+def test_remove_product_from_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
     response = client.request(
         method="DELETE",
@@ -234,7 +234,7 @@ def test_remove_product_from_delivery() -> None:
     assert response.status_code == 201
 
 
-def test_get_orders_from_delivery() -> None:
+def test_get_orders_from_delivery(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.get(
@@ -244,7 +244,7 @@ def test_get_orders_from_delivery() -> None:
     assert response.status_code == 200
 
 
-def test_get_order_by_id() -> None:
+def test_get_order_by_id(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
     response = client.get(
         f"/amap/orders/{order.order_id}",
@@ -253,7 +253,7 @@ def test_get_order_by_id() -> None:
     assert response.status_code == 200
 
 
-def test_make_delivery_orderable() -> None:
+def test_make_delivery_orderable(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
     response = client.post(
         f"/amap/deliveries/{delivery.id}/openordering",
@@ -262,7 +262,7 @@ def test_make_delivery_orderable() -> None:
     assert response.status_code == 204
 
 
-def test_add_order_to_delivery() -> None:
+def test_add_order_to_delivery(client: TestClient) -> None:
     # Enable Redis client for locker
     change_redis_client_status(activated=True)
 
@@ -287,7 +287,7 @@ def test_add_order_to_delivery() -> None:
     assert response.status_code == 201
 
 
-def test_edit_order() -> None:
+def test_edit_order(client: TestClient) -> None:
     # Enable Redis client for locker
     change_redis_client_status(activated=True)
 
@@ -313,7 +313,7 @@ def test_edit_order() -> None:
     assert response.status_code == 204
 
 
-def test_remove_order() -> None:
+def test_remove_order(client: TestClient) -> None:
     # Enable Redis client for locker
     change_redis_client_status(activated=True)
 
@@ -330,7 +330,7 @@ def test_remove_order() -> None:
     assert response.status_code == 204
 
 
-def test_remove_order_by_admin() -> None:
+def test_remove_order_by_admin(client: TestClient) -> None:
     # Enable Redis client for locker
     change_redis_client_status(activated=True)
 
@@ -355,7 +355,7 @@ def test_remove_order_by_admin() -> None:
         change_redis_client_status(activated=False)
 
 
-def test_get_users_cash() -> None:
+def test_get_users_cash(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.get(
@@ -365,7 +365,7 @@ def test_get_users_cash() -> None:
     assert response.status_code == 200
 
 
-def test_get_cash_by_id() -> None:
+def test_get_cash_by_id(client: TestClient) -> None:
     amap_token = create_api_access_token(amap_user)
     student_token = create_api_access_token(student_user)
 
@@ -393,7 +393,7 @@ def test_get_cash_by_id() -> None:
     assert response.status_code == 200
 
 
-def test_create_cash_of_user() -> None:
+def test_create_cash_of_user(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.post(
@@ -404,7 +404,7 @@ def test_create_cash_of_user() -> None:
     assert response.status_code == 201
 
 
-def test_edit_cash_by_id() -> None:
+def test_edit_cash_by_id(client: TestClient) -> None:
     token = create_api_access_token(amap_user)
 
     response = client.post(
@@ -421,7 +421,7 @@ def test_edit_cash_by_id() -> None:
     assert response.status_code == 204
 
 
-def test_get_orders_of_user() -> None:
+def test_get_orders_of_user(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,11 +3,11 @@ import json
 from urllib.parse import parse_qs, urlparse
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from tests.commons import (
-    client,
     create_user_with_groups,
 )
 
@@ -66,7 +66,7 @@ def test_simple_token():
     assert response.status_code == 403  # forbidden
 
 
-def test_authorization_code_flow_PKCE() -> None:
+def test_authorization_code_flow_PKCE(client: TestClient) -> None:
     code_verifier = "AntoineMonBelAntoine"
     code_challenge = "ws9GS3kBIFwDfNghvEk7GRlDvbUkSmZen8q2R4v3lBU="  # base64.urlsafe_b64encode(hashlib.sha256("AntoineMonBelAntoine".encode()).digest())
     data = {
@@ -147,7 +147,7 @@ def test_authorization_code_flow_PKCE() -> None:
     assert response.status_code == 400
 
 
-def test_authorization_code_flow_secret() -> None:
+def test_authorization_code_flow_secret(client: TestClient) -> None:
     data = {
         "client_id": "AppAuthClientWithClientSecret",
         "client_secret": "secret",
@@ -228,7 +228,7 @@ def test_authorization_code_flow_secret() -> None:
     assert response.status_code == 400
 
 
-def test_get_user_info() -> None:
+def test_get_user_info(client: TestClient) -> None:
     # We first need an access token to query user info endpoints #
     data = {
         "client_id": "BaseAuthClient",
@@ -278,7 +278,7 @@ def test_get_user_info() -> None:
     assert json["name"] == user.firstname
 
 
-def test_get_user_info_in_id_token() -> None:
+def test_get_user_info_in_id_token(client: TestClient) -> None:
     # We first need an access token to query user info endpoints #
     data = {
         "client_id": "RalllyAuthClient",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -41,7 +41,7 @@ async def init_objects() -> None:
     )
 
 
-def test_simple_token():
+def test_simple_token(client: TestClient):
     response = client.post(
         "/auth/simple_token",
         data={
@@ -329,7 +329,7 @@ def test_get_user_info_in_id_token(client: TestClient) -> None:
 
 
 # Invalid service configuration
-def test_authorization_code_flow_with_invalid_client_id() -> None:
+def test_authorization_code_flow_with_invalid_client_id(client: TestClient) -> None:
     data_with_invalid_client_id = {
         "client_id": "InvalidClientId",
         "client_secret": "secret",
@@ -351,7 +351,7 @@ def test_authorization_code_flow_with_invalid_client_id() -> None:
 
 
 # Invalid service configuration
-def test_authorization_code_flow_with_invalid_redirect_uri() -> None:
+def test_authorization_code_flow_with_invalid_redirect_uri(client: TestClient) -> None:
     data_with_invalid_client_id = {
         "client_id": "AppAuthClientWithClientSecret",
         "client_secret": "secret",
@@ -373,7 +373,7 @@ def test_authorization_code_flow_with_invalid_redirect_uri() -> None:
 
 
 # Invalid service configuration
-def test_authorization_code_flow_with_invalid_response_type() -> None:
+def test_authorization_code_flow_with_invalid_response_type(client: TestClient) -> None:
     data_with_invalid_client_id = {
         "client_id": "AppAuthClientWithClientSecret",
         "client_secret": "secret",
@@ -397,7 +397,9 @@ def test_authorization_code_flow_with_invalid_response_type() -> None:
 
 
 # Invalid user response
-def test_authorization_code_flow_with_invalid_user_credentials() -> None:
+def test_authorization_code_flow_with_invalid_user_credentials(
+    client: TestClient,
+) -> None:
     data_with_invalid_client_id = {
         "client_id": "AppAuthClientWithClientSecret",
         "client_secret": "secret",
@@ -417,9 +419,9 @@ def test_authorization_code_flow_with_invalid_user_credentials() -> None:
 
 
 # Valid user response
-def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and_user_member_of_an_allowed_group() -> (
-    None
-):
+def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and_user_member_of_an_allowed_group(
+    client: TestClient,
+) -> None:
     # For an user that is a member of a required group #
     data_with_invalid_client_id = {
         "client_id": "AcceptingOnlyECLUsersAuthClient",
@@ -444,9 +446,9 @@ def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and
     assert query["code"][0] != ""
 
 
-def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and_user_not_member_of_an_allowed_group() -> (
-    None
-):
+def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and_user_not_member_of_an_allowed_group(
+    client: TestClient,
+) -> None:
     # For an user that is not a member of a required group #
     data_with_invalid_client_id = {
         "client_id": "AcceptingOnlyECLUsersAuthClient",
@@ -470,9 +472,9 @@ def test_authorization_code_flow_with_auth_client_restricting_allowed_groups_and
     assert query["error"][0] == "consent_required"
 
 
-def test_authorization_code_flow_with_auth_client_restricting_external_users_and_user_external() -> (
-    None
-):
+def test_authorization_code_flow_with_auth_client_restricting_external_users_and_user_external(
+    client: TestClient,
+) -> None:
     # For an user that is not a member of a required group #
     data_with_invalid_client_id = {
         "client_id": "RalllyAuthClient",

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -2,13 +2,13 @@ import datetime
 import uuid
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.booking import models_booking
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -116,7 +116,7 @@ async def init_objects() -> None:
     await add_object_to_db(booking_to_delete)
 
 
-def test_get_managers() -> None:
+def test_get_managers(client: TestClient) -> None:
     response = client.get(
         "/booking/managers",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -124,7 +124,7 @@ def test_get_managers() -> None:
     assert response.status_code == 200
 
 
-def test_post_manager() -> None:
+def test_post_manager(client: TestClient) -> None:
     response = client.post(
         "/booking/managers",
         json={
@@ -137,7 +137,7 @@ def test_post_manager() -> None:
     assert response.status_code == 201
 
 
-def test_edit_manager() -> None:
+def test_edit_manager(client: TestClient) -> None:
     response = client.patch(
         f"/booking/managers/{manager_to_delete.id}",
         json={"name": "Test"},
@@ -152,7 +152,7 @@ def test_edit_manager() -> None:
     assert response.status_code == 204
 
 
-def test_delete_manager() -> None:
+def test_delete_manager(client: TestClient) -> None:
     response = client.delete(
         f"/booking/managers/{manager_to_delete.id}",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -160,7 +160,7 @@ def test_delete_manager() -> None:
     assert response.status_code == 204
 
 
-def test_get_user_managers() -> None:
+def test_get_user_managers(client: TestClient) -> None:
     response = client.get(
         "/booking/managers/users/me",
         headers={"Authorization": f"Bearer {token_manager}"},
@@ -168,7 +168,7 @@ def test_get_user_managers() -> None:
     assert response.status_code == 200
 
 
-def test_get_user_bookings_manage() -> None:
+def test_get_user_bookings_manage(client: TestClient) -> None:
     response = client.get(
         "/booking/bookings/users/me/manage",
         headers={"Authorization": f"Bearer {token_manager}"},
@@ -176,7 +176,7 @@ def test_get_user_bookings_manage() -> None:
     assert response.status_code == 200
 
 
-def test_get_user_bookings_manage_confirmed() -> None:
+def test_get_user_bookings_manage_confirmed(client: TestClient) -> None:
     response = client.get(
         "/booking/bookings/confirmed/users/me/manage",
         headers={"Authorization": f"Bearer {token_manager}"},
@@ -185,7 +185,7 @@ def test_get_user_bookings_manage_confirmed() -> None:
     assert booking_id in [booking["id"] for booking in response.json()]
 
 
-def test_get_bookings_confirmed() -> None:
+def test_get_bookings_confirmed(client: TestClient) -> None:
     response = client.get(
         "/booking/bookings/confirmed",
         headers={"Authorization": f"Bearer {token_manager}"},
@@ -193,7 +193,7 @@ def test_get_bookings_confirmed() -> None:
     assert response.status_code == 200
 
 
-def test_get_user_bookings() -> None:
+def test_get_user_bookings(client: TestClient) -> None:
     response = client.get(
         "/booking/bookings/users/me",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -201,7 +201,7 @@ def test_get_user_bookings() -> None:
     assert response.status_code == 200
 
 
-def test_post_bookings() -> None:
+def test_post_bookings(client: TestClient) -> None:
     response = client.post(
         "/booking/bookings",
         json={
@@ -221,7 +221,7 @@ def test_post_bookings() -> None:
     assert response.status_code == 201
 
 
-def test_edit_booking() -> None:
+def test_edit_booking(client: TestClient) -> None:
     response = client.patch(
         f"/booking/bookings/{booking.id}",
         json={"reason": "Pas un test"},
@@ -230,7 +230,7 @@ def test_edit_booking() -> None:
     assert response.status_code == 204
 
 
-def test_reply_booking() -> None:
+def test_reply_booking(client: TestClient) -> None:
     response = client.patch(
         f"/booking/bookings/{booking.id}/reply/declined",
         headers={"Authorization": f"Bearer {token_manager}"},
@@ -238,7 +238,7 @@ def test_reply_booking() -> None:
     assert response.status_code == 204
 
 
-def test_delete_booking() -> None:
+def test_delete_booking(client: TestClient) -> None:
     response = client.delete(
         f"/booking/bookings/{booking_to_delete.id}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -246,7 +246,7 @@ def test_delete_booking() -> None:
     assert response.status_code == 204
 
 
-def test_get_room() -> None:
+def test_get_room(client: TestClient) -> None:
     response = client.get(
         "/booking/rooms",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -256,7 +256,7 @@ def test_get_room() -> None:
     assert len(json) == 2
 
 
-def test_post_room() -> None:
+def test_post_room(client: TestClient) -> None:
     response = client.post(
         "/booking/rooms",
         json={"name": "Local JE", "manager_id": manager.id},
@@ -265,7 +265,7 @@ def test_post_room() -> None:
     assert response.status_code == 201
 
 
-def test_edit_room() -> None:
+def test_edit_room(client: TestClient) -> None:
     response = client.patch(
         f"/booking/rooms/{room.id}",
         json={"name": "Foyer", "manager_id": manager.id},
@@ -274,7 +274,7 @@ def test_edit_room() -> None:
     assert response.status_code == 204
 
 
-def test_delete_room() -> None:
+def test_delete_room(client: TestClient) -> None:
     # create a room to delete
     response = client.delete(
         f"/booking/rooms/{room_to_delete.id}",

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
@@ -9,7 +10,6 @@ from app.modules.booking.types_booking import Decision
 from app.modules.calendar import models_calendar
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -71,7 +71,7 @@ async def init_objects() -> None:
     await add_object_to_db(calendar_event_to_delete)
 
 
-def test_get_all_events() -> None:
+def test_get_all_events(client: TestClient) -> None:
     global token_bde
 
     response = client.get(
@@ -81,7 +81,7 @@ def test_get_all_events() -> None:
     assert response.status_code == 200
 
 
-def test_get_event() -> None:
+def test_get_event(client: TestClient) -> None:
     global token_bde
 
     response = client.get(
@@ -91,7 +91,7 @@ def test_get_event() -> None:
     assert response.status_code == 200
 
 
-def test_get_nonexistent_event() -> None:
+def test_get_nonexistent_event(client: TestClient) -> None:
     response = client.get(
         "/calendar/events/bad_id",
         headers={"Authorization": f"Bearer {token_bde}"},
@@ -99,7 +99,7 @@ def test_get_nonexistent_event() -> None:
     assert response.status_code == 404
 
 
-def test_add_event() -> None:
+def test_add_event(client: TestClient) -> None:
     global token_bde
 
     response = client.post(
@@ -119,7 +119,7 @@ def test_add_event() -> None:
     assert response.status_code == 201
 
 
-def test_add_event_missing_parameter() -> None:
+def test_add_event_missing_parameter(client: TestClient) -> None:
     """Test to add an event but a parameter is missing. `start` is missing"""
     global token_bde
 
@@ -138,7 +138,7 @@ def test_add_event_missing_parameter() -> None:
     assert response.status_code == 422
 
 
-def test_edit_event() -> None:
+def test_edit_event(client: TestClient) -> None:
     response = client.patch(
         f"/calendar/events/{calendar_event.id}",
         json={"description": "Apprendre à programmer"},
@@ -147,7 +147,7 @@ def test_edit_event() -> None:
     assert response.status_code == 204
 
 
-def test_delete_event() -> None:
+def test_delete_event(client: TestClient) -> None:
     """Test if an admin can delete an event."""
 
     global token_bde
@@ -159,7 +159,7 @@ def test_delete_event() -> None:
     assert response.status_code == 204
 
 
-def test_delete_event_unauthorized_user() -> None:
+def test_delete_event_unauthorized_user(client: TestClient) -> None:
     """Test if a simple user can't delete an event."""
 
     global token_simple
@@ -171,7 +171,7 @@ def test_delete_event_unauthorized_user() -> None:
     assert response.status_code == 403
 
 
-def test_decline_event() -> None:
+def test_decline_event(client: TestClient) -> None:
     response = client.patch(
         f"/calendar/events/{calendar_event.id}/reply/declined",
         headers={"Authorization": f"Bearer {token_bde}"},
@@ -179,7 +179,7 @@ def test_decline_event() -> None:
     assert response.status_code == 204
 
 
-def test_approve_event() -> None:
+def test_approve_event(client: TestClient) -> None:
     global token_bde
     response = client.patch(
         f"/calendar/events/{calendar_event.id}/reply/approved",

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -2,6 +2,7 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
@@ -9,7 +10,6 @@ from app.modules.campaign import models_campaign
 from app.modules.campaign.types_campaign import ListType
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -77,7 +77,7 @@ async def init_objects() -> None:
     await add_object_to_db(voters_CAA)
 
 
-def test_get_sections() -> None:
+def test_get_sections(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
     response = client.get(
         "/campaign/sections",
@@ -88,7 +88,7 @@ def test_get_sections() -> None:
     assert response.status_code == 200
 
 
-def test_add_sections() -> None:
+def test_add_sections(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/sections",
@@ -103,7 +103,7 @@ def test_add_sections() -> None:
     section2id = response.json()["id"]
 
 
-def test_delete_section() -> None:
+def test_delete_section(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.delete(
         f"/campaign/sections/{section2id}",
@@ -112,7 +112,7 @@ def test_delete_section() -> None:
     assert response.status_code == 204
 
 
-def test_get_voters() -> None:
+def test_get_voters(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
     response = client.get(
         "/campaign/voters",
@@ -123,7 +123,7 @@ def test_get_voters() -> None:
     assert response.status_code == 200
 
 
-def test_delete_voter_by_group_id() -> None:
+def test_delete_voter_by_group_id(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.delete(
         f"/campaign/voters/{GroupType.CAA}",
@@ -132,7 +132,7 @@ def test_delete_voter_by_group_id() -> None:
     assert response.status_code == 204
 
 
-def test_delete_voters() -> None:
+def test_delete_voters(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.delete(
         "/campaign/voters",
@@ -141,7 +141,7 @@ def test_delete_voters() -> None:
     assert response.status_code == 204
 
 
-def test_add_voters() -> None:
+def test_add_voters(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/voters",
@@ -153,7 +153,7 @@ def test_add_voters() -> None:
     assert response.status_code == 201
 
 
-def test_get_lists() -> None:
+def test_get_lists(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
     response = client.get(
         "/campaign/lists",
@@ -162,7 +162,7 @@ def test_get_lists() -> None:
     assert response.status_code == 200
 
 
-def test_add_list() -> None:
+def test_add_list(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/lists",
@@ -181,7 +181,7 @@ def test_add_list() -> None:
     list2id = response.json()["id"]
 
 
-def test_delete_list() -> None:
+def test_delete_list(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.delete(
         f"/campaign/lists/{list2id}",
@@ -190,7 +190,7 @@ def test_delete_list() -> None:
     assert response.status_code == 204
 
 
-def test_update_list() -> None:
+def test_update_list(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.patch(
         f"/campaign/lists/{campaign_list.id}",
@@ -203,7 +203,7 @@ def test_update_list() -> None:
     assert response.status_code == 204
 
 
-def test_create_campaigns_logo() -> None:
+def test_create_campaigns_logo(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
 
     with Path("assets/images/default_campaigns_logo.png").open("rb") as image:
@@ -216,7 +216,7 @@ def test_create_campaigns_logo() -> None:
     assert response.status_code == 201
 
 
-def test_vote_if_not_opened() -> None:
+def test_vote_if_not_opened(client: TestClient) -> None:
     # An user should be able to vote if the status is not opened
     token = create_api_access_token(AE_user)
     response = client.post(
@@ -227,7 +227,7 @@ def test_vote_if_not_opened() -> None:
     assert response.status_code == 400
 
 
-def test_open_vote() -> None:
+def test_open_vote(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/status/open",
@@ -238,7 +238,7 @@ def test_open_vote() -> None:
     assert response.status_code == 204
 
 
-def test_read_campaigns_logo() -> None:
+def test_read_campaigns_logo(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
 
     response = client.get(
@@ -249,7 +249,7 @@ def test_read_campaigns_logo() -> None:
     assert response.status_code == 200
 
 
-def test_vote_if_opened() -> None:
+def test_vote_if_opened(client: TestClient) -> None:
     # As the status is now opened, the user should be able to vote
     token = create_api_access_token(AE_user)
     response = client.post(
@@ -260,7 +260,7 @@ def test_vote_if_opened() -> None:
     assert response.status_code == 204
 
 
-def test_vote_a_second_time_for_the_same_section() -> None:
+def test_vote_a_second_time_for_the_same_section(client: TestClient) -> None:
     # An user should not be able to vote twice for the same section
     token = create_api_access_token(AE_user)
     response = client.post(
@@ -271,7 +271,7 @@ def test_vote_a_second_time_for_the_same_section() -> None:
     assert response.status_code == 400
 
 
-def test_get_sections_already_voted() -> None:
+def test_get_sections_already_voted(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
     response = client.get(
         "/campaign/votes",
@@ -280,7 +280,7 @@ def test_get_sections_already_voted() -> None:
     assert response.status_code == 200
 
 
-def test_get_stats_for_section() -> None:
+def test_get_stats_for_section(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.get(
         f"/campaign/stats/{section.id}",
@@ -289,7 +289,7 @@ def test_get_stats_for_section() -> None:
     assert response.status_code == 200
 
 
-def test_get_results_while_open() -> None:
+def test_get_results_while_open(client: TestClient) -> None:
     # As the status is open, nobody should be able to access results
     token = create_api_access_token(CAA_user)
     response = client.get(
@@ -299,7 +299,7 @@ def test_get_results_while_open() -> None:
     assert response.status_code == 400
 
 
-def test_close_vote() -> None:
+def test_close_vote(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/status/close",
@@ -308,7 +308,7 @@ def test_close_vote() -> None:
     assert response.status_code == 204
 
 
-def test_count_vote() -> None:
+def test_count_vote(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/status/counting",
@@ -317,7 +317,7 @@ def test_count_vote() -> None:
     assert response.status_code == 204
 
 
-def test_get_results_while_counting() -> None:
+def test_get_results_while_counting(client: TestClient) -> None:
     # As the status is counting, only CAA user should be able to access results
     token = create_api_access_token(CAA_user)
     response = client.get(
@@ -327,7 +327,7 @@ def test_get_results_while_counting() -> None:
     assert response.status_code == 200
 
 
-def test_publish_vote() -> None:
+def test_publish_vote(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/status/published",
@@ -336,7 +336,7 @@ def test_publish_vote() -> None:
     assert response.status_code == 204
 
 
-def test_get_results_while_published() -> None:
+def test_get_results_while_published(client: TestClient) -> None:
     token = create_api_access_token(AE_user)
     response = client.get(
         "/campaign/results",
@@ -345,7 +345,7 @@ def test_get_results_while_published() -> None:
     assert response.status_code == 200
 
 
-def test_reset_votes() -> None:
+def test_reset_votes(client: TestClient) -> None:
     token = create_api_access_token(CAA_user)
     response = client.post(
         "/campaign/status/reset",

--- a/tests/test_cinema.py
+++ b/tests/test_cinema.py
@@ -2,13 +2,13 @@ import datetime
 import uuid
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.cinema import models_cinema
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -47,7 +47,7 @@ async def init_objects() -> None:
     await add_object_to_db(session)
 
 
-def test_get_sessions() -> None:
+def test_get_sessions(client: TestClient) -> None:
     response = client.get(
         "/cinema/sessions",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -55,7 +55,7 @@ def test_get_sessions() -> None:
     assert response.status_code == 200
 
 
-def test_post_session() -> None:
+def test_post_session(client: TestClient) -> None:
     response = client.post(
         "/cinema/sessions",
         json={
@@ -69,7 +69,7 @@ def test_post_session() -> None:
     assert response.status_code == 201
 
 
-def test_edit_session() -> None:
+def test_edit_session(client: TestClient) -> None:
     response = client.patch(
         f"/cinema/sessions/{session.id}",
         json={"name": "Titanoc"},
@@ -78,7 +78,7 @@ def test_edit_session() -> None:
     assert response.status_code == 200
 
 
-def test_delete_session() -> None:
+def test_delete_session(client: TestClient) -> None:
     response = client.delete(
         f"/cinema/sessions/{session.id}",
         headers={"Authorization": f"Bearer {token_cinema}"},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,10 @@
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -33,7 +33,7 @@ async def init_objects() -> None:
     await add_object_to_db(module_visibility)
 
 
-def test_get_module_visibility() -> None:
+def test_get_module_visibility(client: TestClient) -> None:
     response = client.get(
         "/module-visibility",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -41,7 +41,7 @@ def test_get_module_visibility() -> None:
     assert response.status_code == 200
 
 
-def test_get_my_module_visibility() -> None:
+def test_get_my_module_visibility(client: TestClient) -> None:
     response = client.get(
         "/module-visibility/me",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -49,7 +49,7 @@ def test_get_my_module_visibility() -> None:
     assert response.status_code == 200
 
 
-def test_add_module_visibility() -> None:
+def test_add_module_visibility(client: TestClient) -> None:
     response = client.post(
         "/module-visibility/",
         json={
@@ -61,7 +61,7 @@ def test_add_module_visibility() -> None:
     assert response.status_code == 201
 
 
-def test_delete_loaners() -> None:
+def test_delete_loaners(client: TestClient) -> None:
     response = client.delete(
         f"/module-visibility/{root}/{group_id}",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -69,7 +69,7 @@ def test_delete_loaners() -> None:
     assert response.status_code == 204
 
 
-def test_get_information() -> None:
+def test_get_information(client: TestClient) -> None:
     response = client.get(
         "/information",
     )
@@ -78,42 +78,42 @@ def test_get_information() -> None:
     assert data["ready"] is True
 
 
-def test_get_privacy() -> None:
+def test_get_privacy(client: TestClient) -> None:
     response = client.get(
         "/privacy",
     )
     assert response.status_code == 200
 
 
-def test_get_terms_and_conditions() -> None:
+def test_get_terms_and_conditions(client: TestClient) -> None:
     response = client.get(
         "/terms-and-conditions",
     )
     assert response.status_code == 200
 
 
-def test_get_support() -> None:
+def test_get_support(client: TestClient) -> None:
     response = client.get(
         "/support",
     )
     assert response.status_code == 200
 
 
-def test_get_security_txt() -> None:
+def test_get_security_txt(client: TestClient) -> None:
     response = client.get(
         "/security.txt",
     )
     assert response.status_code == 200
 
 
-def test_get_wellknown_security_txt() -> None:
+def test_get_wellknown_security_txt(client: TestClient) -> None:
     response = client.get(
         "/.well-known/security.txt",
     )
     assert response.status_code == 200
 
 
-def test_get_stylesheet() -> None:
+def test_get_stylesheet(client: TestClient) -> None:
     response = client.get(
         "/style/connexion.css",
     )
@@ -126,14 +126,14 @@ def test_get_stylesheet() -> None:
     assert response.status_code == 404
 
 
-def test_get_favicon() -> None:
+def test_get_favicon(client: TestClient) -> None:
     response = client.get(
         "/favicon.ico",
     )
     assert response.status_code == 200
 
 
-def test_cors_authorized_origin() -> None:
+def test_cors_authorized_origin(client: TestClient) -> None:
     origin = "https://test-authorized-origin.com"
     headers = {
         "Access-Control-Request-Method": "GET",
@@ -143,7 +143,7 @@ def test_cors_authorized_origin() -> None:
     assert response.headers["access-control-allow-origin"] == origin
 
 
-def test_cors_unauthorized_origin() -> None:
+def test_cors_unauthorized_origin(client: TestClient) -> None:
     origin = "https://test-UNauthorized-origin.com"
     headers = {
         "Access-Control-Request-Method": "GET",

--- a/tests/test_flappybird.py
+++ b/tests/test_flappybird.py
@@ -2,13 +2,13 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.flappybird import models_flappybird
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -19,7 +19,7 @@ token: str = ""
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     global user
     user = await create_user_with_groups([GroupType.student])
 
@@ -48,7 +48,7 @@ async def init_objects():
     await add_object_to_db(flappybird_best_score)
 
 
-def test_get_flappybird_score():
+def test_get_flappybird_score(client: TestClient) -> None:
     response = client.get(
         "/flappybird/scores/",
         headers={"Authorization": f"Bearer {token}"},
@@ -56,7 +56,7 @@ def test_get_flappybird_score():
     assert response.status_code == 200
 
 
-def test_get_current_user_flappybird_personal_best():
+def test_get_current_user_flappybird_personal_best(client: TestClient) -> None:
     response = client.get(
         "/flappybird/scores/me/",
         headers={"Authorization": f"Bearer {token}"},
@@ -64,7 +64,7 @@ def test_get_current_user_flappybird_personal_best():
     assert response.status_code == 200
 
 
-def test_create_flappybird_score():
+def test_create_flappybird_score(client: TestClient) -> None:
     response = client.post(
         "/flappybird/scores",
         json={

--- a/tests/test_flappybird.py
+++ b/tests/test_flappybird.py
@@ -75,7 +75,7 @@ def test_create_flappybird_score(client: TestClient) -> None:
     assert response.status_code == 201
 
 
-def test_update_flappybird_score():
+def test_update_flappybird_score(client: TestClient):
     response = client.post(
         "/flappybird/scores",
         json={

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,10 +1,10 @@
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -29,7 +29,7 @@ async def init_objects() -> None:
     admin_user = await create_user_with_groups([GroupType.admin])
 
 
-def test_read_groups() -> None:
+def test_read_groups(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.get(
@@ -39,7 +39,7 @@ def test_read_groups() -> None:
     assert response.status_code == 200
 
 
-def test_read_group() -> None:
+def test_read_group(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.get(
@@ -51,7 +51,7 @@ def test_read_group() -> None:
     assert data["name"] == "eclair"
 
 
-def test_create_group() -> None:
+def test_create_group(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.post(
@@ -65,7 +65,7 @@ def test_create_group() -> None:
     assert response.status_code == 201
 
 
-def test_update_group() -> None:
+def test_update_group(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.patch(
@@ -78,7 +78,7 @@ def test_update_group() -> None:
     assert response.status_code == 204
 
 
-def test_create_membership() -> None:
+def test_create_membership(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.post(
@@ -93,7 +93,7 @@ def test_create_membership() -> None:
     assert response.status_code == 201
 
 
-def test_delete_membership() -> None:
+def test_delete_membership(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.request(

--- a/tests/test_loan.py
+++ b/tests/test_loan.py
@@ -3,13 +3,13 @@ import uuid
 from datetime import timedelta
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from app.modules.loan import models_loan
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -103,7 +103,7 @@ async def init_objects() -> None:
     token_simple = create_api_access_token(loan_user_simple)
 
 
-def test_get_loaners() -> None:
+def test_get_loaners(client: TestClient) -> None:
     response = client.get(
         "/loans/loaners/",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -111,7 +111,7 @@ def test_get_loaners() -> None:
     assert response.status_code == 200
 
 
-def test_create_loaners() -> None:
+def test_create_loaners(client: TestClient) -> None:
     response = client.post(
         "/loans/loaners/",
         json={
@@ -123,7 +123,7 @@ def test_create_loaners() -> None:
     assert response.status_code == 201
 
 
-def test_update_loaners() -> None:
+def test_update_loaners(client: TestClient) -> None:
     response = client.patch(
         f"/loans/loaners/{loaner_to_delete.id}",
         json={
@@ -135,7 +135,7 @@ def test_update_loaners() -> None:
     assert response.status_code == 204
 
 
-def test_delete_loaners() -> None:
+def test_delete_loaners(client: TestClient) -> None:
     response = client.delete(
         f"/loans/loaners/{loaner_to_delete.id}",
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -143,7 +143,7 @@ def test_delete_loaners() -> None:
     assert response.status_code == 204
 
 
-def test_get_loans_by_loaner() -> None:
+def test_get_loans_by_loaner(client: TestClient) -> None:
     response = client.get(
         f"/loans/loaners/{loaner.id}/loans",
         headers={"Authorization": f"Bearer {token_loaner}"},
@@ -151,7 +151,7 @@ def test_get_loans_by_loaner() -> None:
     assert response.status_code == 200
 
 
-def test_get_items_for_loaner() -> None:
+def test_get_items_for_loaner(client: TestClient) -> None:
     response = client.get(
         f"/loans/loaners/{loaner.id}/items",
         headers={"Authorization": f"Bearer {token_loaner}"},
@@ -159,7 +159,7 @@ def test_get_items_for_loaner() -> None:
     assert response.status_code == 200
 
 
-def test_create_items_for_loaner() -> None:
+def test_create_items_for_loaner(client: TestClient) -> None:
     response = client.post(
         f"/loans/loaners/{loaner.id}/items",
         json={
@@ -173,7 +173,7 @@ def test_create_items_for_loaner() -> None:
     assert response.status_code == 201
 
 
-def test_update_items_for_loaner() -> None:
+def test_update_items_for_loaner(client: TestClient) -> None:
     response = client.patch(
         f"/loans/loaners/{loaner.id}/items/{item.id}",
         json={
@@ -187,7 +187,7 @@ def test_update_items_for_loaner() -> None:
     assert response.status_code == 204
 
 
-def test_delete_loaner_item() -> None:
+def test_delete_loaner_item(client: TestClient) -> None:
     response = client.delete(
         f"/loans/loaners/{loaner.id}/items/{item_to_delete.id}",
         headers={"Authorization": f"Bearer {token_loaner}"},
@@ -195,7 +195,7 @@ def test_delete_loaner_item() -> None:
     assert response.status_code == 204
 
 
-def test_get_current_user_loans() -> None:
+def test_get_current_user_loans(client: TestClient) -> None:
     response = client.get(
         "/loans/users/me",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -203,7 +203,7 @@ def test_get_current_user_loans() -> None:
     assert response.status_code == 200
 
 
-def test_get_current_user_loaners() -> None:
+def test_get_current_user_loaners(client: TestClient) -> None:
     response = client.get(
         "/loans/users/me/loaners",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -211,7 +211,7 @@ def test_get_current_user_loaners() -> None:
     assert response.status_code == 200
 
 
-def test_create_loan() -> None:
+def test_create_loan(client: TestClient) -> None:
     response = client.post(
         "/loans/",
         json={
@@ -233,7 +233,7 @@ def test_create_loan() -> None:
     assert response.status_code == 201
 
 
-def test_update_loan() -> None:
+def test_update_loan(client: TestClient) -> None:
     response = client.patch(
         f"/loans/{loan.id}",
         json={
@@ -255,7 +255,7 @@ def test_update_loan() -> None:
     assert response.status_code == 204
 
 
-def test_return_loan() -> None:
+def test_return_loan(client: TestClient) -> None:
     response = client.post(
         f"/loans/{loan.id}/return",
         headers={"Authorization": f"Bearer {token_loaner}"},
@@ -263,7 +263,7 @@ def test_return_loan() -> None:
     assert response.status_code == 204
 
 
-def test_extend_loan() -> None:
+def test_extend_loan(client: TestClient) -> None:
     response = client.post(
         f"/loans/{loan.id}/extend",
         json={
@@ -274,7 +274,7 @@ def test_extend_loan() -> None:
     assert response.status_code == 204
 
 
-def test_delete_loan() -> None:
+def test_delete_loan(client: TestClient) -> None:
     response = client.delete(
         f"/loans/{loan.id}",
         headers={"Authorization": f"Bearer {token_loaner}"},

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -16,8 +16,7 @@ from pytest_alembic.tests.experimental import downgrade_leaves_no_trace  # noqa:
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Connection
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test_migration.db"
-
+from tests.commons import SQLALCHEMY_DATABASE_URL_SYNC
 
 pre_test_upgrade_dict: dict[
     str,
@@ -96,12 +95,9 @@ def alembic_connection() -> Generator[Connection, None, None]:
 
     Due to an issue with event loop, we can't run Alembic from asynchronous functions. The tests can't be async, so we need to use a synchronous connection.
     """
-    # We need to delete the test database before each test
-    Path("test_migration.db").unlink(missing_ok=True)
-
     # We use `echo=False` to disable SQLAlchemy logging for migrations
     # as errors are easier to see without all SQLAlchemy info
-    connectable = create_engine(SQLALCHEMY_DATABASE_URL, echo=False)
+    connectable = create_engine(SQLALCHEMY_DATABASE_URL_SYNC, echo=False)
 
     with connectable.begin() as connection:
         yield connection

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,9 +1,9 @@
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
 from tests.commons import (
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -21,13 +21,13 @@ TOPIC_4 = "cinema_notsubscribed"
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     global admin_user, admin_user_token
     admin_user = await create_user_with_groups([GroupType.admin])
     admin_user_token = create_api_access_token(admin_user)
 
 
-def test_register_firebase_device():
+def test_register_firebase_device(client: TestClient) -> None:
     response = client.post(
         "/notification/devices",
         json={
@@ -40,7 +40,7 @@ def test_register_firebase_device():
     assert response.status_code == 204
 
 
-def test_register_a_second_time_a_firebase_device():
+def test_register_a_second_time_a_firebase_device(client: TestClient) -> None:
     # One user can and should register a device at least once a month
     response = client.post(
         "/notification/devices",
@@ -54,7 +54,7 @@ def test_register_a_second_time_a_firebase_device():
     assert response.status_code == 204
 
 
-def test_register_second_firebase_device():
+def test_register_second_firebase_device(client: TestClient) -> None:
     response = client.post(
         "/notification/devices",
         json={
@@ -67,7 +67,7 @@ def test_register_second_firebase_device():
     assert response.status_code == 204
 
 
-def test_unregister_firebase_device():
+def test_unregister_firebase_device(client: TestClient) -> None:
     response = client.delete(
         f"/notification/devices/{FIREBASE_TOKEN_2}",
         headers={
@@ -77,7 +77,7 @@ def test_unregister_firebase_device():
     assert response.status_code == 204
 
 
-def test_get_devices():
+def test_get_devices(client: TestClient) -> None:
     response = client.get(
         "/notification/devices/",
         headers={
@@ -90,14 +90,14 @@ def test_get_devices():
     assert json[0]["firebase_device_token"] == FIREBASE_TOKEN_1
 
 
-def test_get_messages():
+def test_get_messages(client: TestClient) -> None:
     response = client.get(
         f"/notification/messages/{FIREBASE_TOKEN_1}",
     )
     assert response.status_code == 200
 
 
-def test_subscribe_to_topic():
+def test_subscribe_to_topic(client: TestClient) -> None:
     response = client.post(
         f"/notification/topics/{TOPIC_1}/subscribe",
         headers={
@@ -121,7 +121,7 @@ def test_subscribe_to_topic():
     assert response.status_code == 204
 
 
-def test_un_subscribe_to_topic():
+def test_un_subscribe_to_topic(client: TestClient) -> None:
     response = client.post(
         f"/notification/topics/{TOPIC_3}/unsubscribe",
         headers={
@@ -131,7 +131,9 @@ def test_un_subscribe_to_topic():
     assert response.status_code == 204
 
 
-def test_un_subscribe_to_topic_the_user_is_not_subscribed_to():
+def test_un_subscribe_to_topic_the_user_is_not_subscribed_to(
+    client: TestClient,
+) -> None:
     response = client.post(
         f"/notification/topics/{TOPIC_4}/unsubscribe",
         headers={
@@ -141,7 +143,7 @@ def test_un_subscribe_to_topic_the_user_is_not_subscribed_to():
     assert response.status_code == 204
 
 
-def test_get_topic():
+def test_get_topic(client: TestClient) -> None:
     response = client.get(
         "/notification/topics/",
         headers={
@@ -152,7 +154,7 @@ def test_get_topic():
     assert response.json() == [TOPIC_1]
 
 
-def test_get_topic_identifier():
+def test_get_topic_identifier(client: TestClient) -> None:
     response = client.get(
         f"/notification/topics/{TOPIC_1}",
         headers={

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -2,6 +2,7 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
@@ -9,7 +10,6 @@ from app.modules.phonebook import models_phonebook, schemas_phonebook
 from app.modules.phonebook.types_phonebook import Kinds, RoleTags
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -33,7 +33,7 @@ token_simple: str
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     global phonebook_user_BDE
     phonebook_user_BDE = await create_user_with_groups(
         [GroupType.student, GroupType.BDE],
@@ -129,7 +129,7 @@ async def init_objects():
 # ---------------------------------------------------------------------------- #
 #                                  Kinds tests                                 #
 # ---------------------------------------------------------------------------- #
-def test_get_all_association_kinds_simple():
+def test_get_all_association_kinds_simple(client: TestClient) -> None:
     response = client.get(
         "/phonebook/associations/kinds",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -140,7 +140,7 @@ def test_get_all_association_kinds_simple():
 # ---------------------------------------------------------------------------- #
 #                                Roletags tests                                #
 # ---------------------------------------------------------------------------- #
-def test_get_all_roletags_simple():
+def test_get_all_roletags_simple(client: TestClient) -> None:
     response = client.get(
         "/phonebook/roletags/",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -151,7 +151,7 @@ def test_get_all_roletags_simple():
 # ---------------------------------------------------------------------------- #
 #                              Associations tests                              #
 # ---------------------------------------------------------------------------- #
-def test_get_all_associations():
+def test_get_all_associations(client: TestClient) -> None:
     response = client.get(
         "/phonebook/associations/",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -159,7 +159,7 @@ def test_get_all_associations():
     assert response.status_code == 200
 
 
-def test_create_association_admin():
+def test_create_association_admin(client: TestClient) -> None:
     response = client.post(
         "/phonebook/associations/",
         json={
@@ -173,7 +173,7 @@ def test_create_association_admin():
     assert response.status_code == 201
 
 
-def test_create_association_simple():
+def test_create_association_simple(client: TestClient) -> None:
     response = client.post(
         "/phonebook/associations/",
         json={
@@ -187,7 +187,7 @@ def test_create_association_simple():
     assert response.status_code == 403
 
 
-def test_update_association_admin():
+def test_update_association_admin(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/{association.id}",
         json={
@@ -199,7 +199,7 @@ def test_update_association_admin():
     assert response.status_code == 204
 
 
-def test_update_association_president():
+def test_update_association_president(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/{association.id}",
         json={
@@ -211,7 +211,7 @@ def test_update_association_president():
     assert response.status_code == 204
 
 
-def test_update_association_simple():
+def test_update_association_simple(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/{association.id}/",
         json={
@@ -223,7 +223,7 @@ def test_update_association_simple():
     assert response.status_code == 403
 
 
-def test_delete_association_admin():
+def test_delete_association_admin(client: TestClient) -> None:
     response = client.delete(
         f"/phonebook/associations/{associations_to_delete_admin.id}/",
         headers={"Authorization": f"Bearer {token_BDE}"},
@@ -231,7 +231,7 @@ def test_delete_association_admin():
     assert response.status_code == 204
 
 
-def test_delete_association_simple():
+def test_delete_association_simple(client: TestClient) -> None:
     response = client.delete(
         f"/phonebook/associations/{associations_to_delete_simple.id}/",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -242,7 +242,7 @@ def test_delete_association_simple():
 # ---------------------------------------------------------------------------- #
 #                               Memberships tests                              #
 # ---------------------------------------------------------------------------- #
-def test_add_membership_admin():
+def test_add_membership_admin(client: TestClient) -> None:
     response = client.post(
         "/phonebook/associations/memberships",
         json={
@@ -257,7 +257,7 @@ def test_add_membership_admin():
     assert response.status_code == 201
 
 
-def test_add_membership_simple():
+def test_add_membership_simple(client: TestClient) -> None:
     response = client.post(
         "/phonebook/associations/memberships",
         json={
@@ -272,7 +272,7 @@ def test_add_membership_simple():
     assert response.status_code == 403
 
 
-def test_update_membership_admin():
+def test_update_membership_admin(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/memberships/{membership.id}",
         json={
@@ -283,7 +283,7 @@ def test_update_membership_admin():
     assert response.status_code == 204
 
 
-def test_update_membership_president():
+def test_update_membership_president(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/memberships/{membership.id}",
         json={
@@ -294,7 +294,7 @@ def test_update_membership_president():
     assert response.status_code == 204
 
 
-def test_update_membership_simple():
+def test_update_membership_simple(client: TestClient) -> None:
     response = client.patch(
         f"/phonebook/associations/memberships/{membership.id}",
         json={
@@ -305,7 +305,7 @@ def test_update_membership_simple():
     assert response.status_code == 403
 
 
-def test_delete_membership_admin():
+def test_delete_membership_admin(client: TestClient) -> None:
     response = client.delete(
         f"/phonebook/associations/memberships/{membership_to_delete_admin.id}",
         headers={"Authorization": f"Bearer {token_BDE}"},
@@ -313,7 +313,7 @@ def test_delete_membership_admin():
     assert response.status_code == 204
 
 
-def test_delete_membership_president():
+def test_delete_membership_president(client: TestClient) -> None:
     response = client.delete(
         f"/phonebook/associations/memberships/{membership_to_delete_president.id}",
         headers={"Authorization": f"Bearer {token_president}"},
@@ -321,7 +321,7 @@ def test_delete_membership_president():
     assert response.status_code == 204
 
 
-def test_delete_membership_simple():
+def test_delete_membership_simple(client: TestClient) -> None:
     response = client.delete(
         f"/phonebook/associations/memberships/{membership_to_delete_simple.id}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -332,7 +332,7 @@ def test_delete_membership_simple():
 # ---------------------------------------------------------------------------- #
 #                                 Members tests                                #
 # ---------------------------------------------------------------------------- #
-def test_get_members_by_association_id_simple():
+def test_get_members_by_association_id_simple(client: TestClient) -> None:
     response = client.get(
         f"/phonebook/associations/{association.id}/members/{association.mandate_year}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -346,7 +346,7 @@ def test_get_members_by_association_id_simple():
         )
 
 
-def test_get_member_by_id_simple():
+def test_get_member_by_id_simple(client: TestClient) -> None:
     response = client.get(
         f"phonebook/member/{phonebook_user_simple.id}",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -361,7 +361,7 @@ def test_get_member_by_id_simple():
 # ---------------------------------------------------------------------------- #
 #                                  Logos tests                                 #
 # ---------------------------------------------------------------------------- #
-def test_create_association_picture_admin():
+def test_create_association_picture_admin(client: TestClient) -> None:
     with Path("assets/images/default_association_picture.png").open("rb") as image:
         response = client.post(
             f"/phonebook/associations/{association.id}/picture",
@@ -371,7 +371,7 @@ def test_create_association_picture_admin():
     assert response.status_code == 201
 
 
-def test_create_association_picture_simple():
+def test_create_association_picture_simple(client: TestClient) -> None:
     with Path("assets/images/default_association_picture.png").open("rb") as image:
         response = client.post(
             f"/phonebook/associations/{association.id}/picture",
@@ -381,7 +381,7 @@ def test_create_association_picture_simple():
     assert response.status_code == 403
 
 
-def test_get_association_picture_simple():
+def test_get_association_picture_simple(client: TestClient) -> None:
     response = client.get(
         f"/phonebook/associations/{association.id}/picture",
         headers={"Authorization": f"Bearer {token_simple}"},

--- a/tests/test_raffle.py
+++ b/tests/test_raffle.py
@@ -2,6 +2,7 @@ import uuid
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core import models_core
 from app.core.groups.groups_type import GroupType
@@ -10,7 +11,6 @@ from app.modules.raffle.types_raffle import RaffleStatusType
 from tests.commons import (
     add_object_to_db,
     change_redis_client_status,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -138,7 +138,7 @@ async def init_objects() -> None:
     await add_object_to_db(cash)
 
 
-def test_get_raffles() -> None:
+def test_get_raffles(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(
@@ -148,7 +148,7 @@ def test_get_raffles() -> None:
     assert response.status_code == 200
 
 
-def test_create_raffle() -> None:
+def test_create_raffle(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.post(
@@ -163,7 +163,7 @@ def test_create_raffle() -> None:
     assert response.status_code == 201
 
 
-def test_edit_raffle() -> None:
+def test_edit_raffle(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.patch(
@@ -185,7 +185,7 @@ def test_edit_raffle() -> None:
     assert modified_raffle["name"] == "testupdate"
 
 
-def test_create_raffle_logo() -> None:
+def test_create_raffle_logo(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     with Path("assets/images/default_campaigns_logo.png").open("rb") as image:
@@ -198,7 +198,7 @@ def test_create_raffle_logo() -> None:
     assert response.status_code == 201
 
 
-def test_read_raffle_logo() -> None:
+def test_read_raffle_logo(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.get(
@@ -209,7 +209,7 @@ def test_read_raffle_logo() -> None:
     assert response.status_code == 200
 
 
-def test_create_prize_picture() -> None:
+def test_create_prize_picture(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     with Path("assets/images/default_campaigns_logo.png").open("rb") as image:
@@ -222,7 +222,7 @@ def test_create_prize_picture() -> None:
     assert response.status_code == 201
 
 
-def test_read_prize_picture() -> None:
+def test_read_prize_picture(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.get(
@@ -233,7 +233,7 @@ def test_read_prize_picture() -> None:
     assert response.status_code == 200
 
 
-def test_open_raffle() -> None:
+def test_open_raffle(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.patch(
@@ -251,7 +251,7 @@ def test_open_raffle() -> None:
     assert modified_raffle["status"] == RaffleStatusType.open
 
 
-def test_lock_raffle() -> None:
+def test_lock_raffle(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.patch(
@@ -269,7 +269,7 @@ def test_lock_raffle() -> None:
     assert modified_raffle["status"] == RaffleStatusType.lock
 
 
-def test_get_raffle_stats() -> None:
+def test_get_raffle_stats(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(
@@ -281,7 +281,7 @@ def test_get_raffle_stats() -> None:
 
 
 # # tickets
-def test_get_tickets() -> None:
+def test_get_tickets(client: TestClient) -> None:
     token = create_api_access_token(admin_user)
 
     response = client.get(
@@ -291,7 +291,7 @@ def test_get_tickets() -> None:
     assert response.status_code == 200
 
 
-def test_get_tickets_by_raffle_id() -> None:
+def test_get_tickets_by_raffle_id(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.get(
@@ -301,7 +301,7 @@ def test_get_tickets_by_raffle_id() -> None:
     assert response.status_code == 200
 
 
-def test_get_tickets_by_user_id() -> None:
+def test_get_tickets_by_user_id(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(
@@ -313,7 +313,7 @@ def test_get_tickets_by_user_id() -> None:
     assert len(response.json()) == 2
 
 
-def test_buy_tickets() -> None:
+def test_buy_tickets(client: TestClient) -> None:
     # Enable Redis client for locker
     change_redis_client_status(activated=True)
 
@@ -357,7 +357,7 @@ def test_buy_tickets() -> None:
 
 
 # # pack_tickets
-def test_get_packtickets() -> None:
+def test_get_packtickets(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.get(
@@ -367,7 +367,7 @@ def test_get_packtickets() -> None:
     assert response.status_code == 200
 
 
-def test_get_packtickets_by_raffle_id() -> None:
+def test_get_packtickets_by_raffle_id(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.get(
@@ -377,7 +377,7 @@ def test_get_packtickets_by_raffle_id() -> None:
     assert response.status_code == 200
 
 
-def test_create_packtickets() -> None:
+def test_create_packtickets(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.post(
@@ -392,7 +392,7 @@ def test_create_packtickets() -> None:
     assert response.status_code == 201
 
 
-def test_edit_packtickets() -> None:
+def test_edit_packtickets(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.patch(
@@ -407,7 +407,7 @@ def test_edit_packtickets() -> None:
     assert response.status_code == 204
 
 
-def test_delete_packtickets() -> None:
+def test_delete_packtickets(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.delete(
@@ -418,7 +418,7 @@ def test_delete_packtickets() -> None:
 
 
 # # prizes
-def test_get_prizes() -> None:
+def test_get_prizes(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(
@@ -428,7 +428,7 @@ def test_get_prizes() -> None:
     assert response.status_code == 200
 
 
-def test_get_prizes_by_raffle_id() -> None:
+def test_get_prizes_by_raffle_id(client: TestClient) -> None:
     token = create_api_access_token(student_user)
 
     response = client.get(
@@ -439,7 +439,7 @@ def test_get_prizes_by_raffle_id() -> None:
     assert response.json() != []
 
 
-def test_create_prizes() -> None:
+def test_create_prizes(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.post(
@@ -455,7 +455,7 @@ def test_create_prizes() -> None:
     assert response.status_code == 201
 
 
-def test_edit_prizes() -> None:
+def test_edit_prizes(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.patch(
@@ -471,7 +471,7 @@ def test_edit_prizes() -> None:
     assert response.status_code == 204
 
 
-def test_draw_prizes() -> None:
+def test_draw_prizes(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.post(
@@ -483,7 +483,7 @@ def test_draw_prizes() -> None:
     assert tickets[0]["prize"] is not None
 
 
-def test_delete_prizes() -> None:
+def test_delete_prizes(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.delete(
@@ -493,7 +493,7 @@ def test_delete_prizes() -> None:
     assert response.status_code == 204
 
 
-def test_delete_raffle() -> None:
+def test_delete_raffle(client: TestClient) -> None:
     token = create_api_access_token(BDE_user)
 
     response = client.delete(

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,9 @@
-from tests.commons import change_redis_client_status, client, settings
+from fastapi.testclient import TestClient
+
+from tests.commons import change_redis_client_status, settings
 
 
-def test_limiter() -> None:
+def test_limiter(client: TestClient) -> None:
     change_redis_client_status(activated=True)
     try:
         for _ in range(settings.REDIS_LIMIT - 1):

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -3,12 +3,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest_asyncio
+from fastapi.testclient import TestClient
 
 from app.core.groups.groups_type import GroupType
 from app.modules.recommendation import models_recommendation
 from tests.commons import (
     add_object_to_db,
-    client,
     create_api_access_token,
     create_user_with_groups,
 )
@@ -19,7 +19,7 @@ recommendation: models_recommendation.Recommendation
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     user_simple = await create_user_with_groups([GroupType.student])
 
     global token_simple
@@ -42,7 +42,7 @@ async def init_objects():
     await add_object_to_db(recommendation)
 
 
-def test_create_picture():
+def test_create_picture(client: TestClient) -> None:
     with Path("assets/images/default_recommendation.png").open("rb") as image:
         response = client.post(
             f"/recommendation/recommendations/{recommendation.id}/picture",
@@ -52,7 +52,7 @@ def test_create_picture():
     assert response.status_code == 201
 
 
-def test_create_picture_for_non_existing_recommendation():
+def test_create_picture_for_non_existing_recommendation(client: TestClient) -> None:
     with Path("assets/images/default_recommendation.png").open("rb") as image:
         false_id = "be3017e8-ae8b-4488-a21a-41547c9cc846"
         response = client.post(
@@ -63,7 +63,7 @@ def test_create_picture_for_non_existing_recommendation():
     assert response.status_code == 404
 
 
-def test_get_picture():
+def test_get_picture(client: TestClient) -> None:
     response = client.get(
         f"/recommendation/recommendations/{recommendation.id}/picture",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -71,7 +71,7 @@ def test_get_picture():
     assert response.status_code == 200
 
 
-def test_get_recommendation():
+def test_get_recommendation(client: TestClient) -> None:
     response = client.get(
         "/recommendation/recommendations",
         headers={"Authorization": f"Bearer {token_simple}"},
@@ -79,7 +79,7 @@ def test_get_recommendation():
     assert response.status_code == 200
 
 
-def test_create_recommendation():
+def test_create_recommendation(client: TestClient) -> None:
     response = client.post(
         "/recommendation/recommendations",
         json={
@@ -93,7 +93,7 @@ def test_create_recommendation():
     assert response.status_code == 201
 
 
-def test_create_recommendation_with_no_body():
+def test_create_recommendation_with_no_body(client: TestClient) -> None:
     response = client.post(
         "/recommendation/recommendations",
         json={},
@@ -102,7 +102,7 @@ def test_create_recommendation_with_no_body():
     assert response.status_code == 422
 
 
-def test_edit_recommendation():
+def test_edit_recommendation(client: TestClient) -> None:
     response = client.patch(
         f"/recommendation/recommendations/{recommendation.id}",
         json={"title": "Nouveau titre"},
@@ -111,7 +111,7 @@ def test_edit_recommendation():
     assert response.status_code == 204
 
 
-def test_edit_recommendation_with_no_body():
+def test_edit_recommendation_with_no_body(client: TestClient) -> None:
     response = client.patch(
         f"/recommendation/recommendations/{recommendation.id}",
         json={},
@@ -120,7 +120,7 @@ def test_edit_recommendation_with_no_body():
     assert response.status_code == 204
 
 
-def test_edit_for_non_existing_recommendation():
+def test_edit_for_non_existing_recommendation(client: TestClient) -> None:
     false_id = "098cdfb7-609a-493f-8d5a-47bbdba213da"
     response = client.patch(
         f"/recommendation/recommendations/{false_id}",
@@ -130,7 +130,7 @@ def test_edit_for_non_existing_recommendation():
     assert response.status_code == 404
 
 
-def test_delete_recommendation():
+def test_delete_recommendation(client: TestClient) -> None:
     response = client.delete(
         f"/recommendation/recommendations/{recommendation.id}",
         headers={"Authorization": f"Bearer {token_BDE}"},
@@ -138,7 +138,7 @@ def test_delete_recommendation():
     assert response.status_code == 204
 
 
-def test_delete_for_non_existing_recommendation():
+def test_delete_for_non_existing_recommendation(client: TestClient) -> None:
     false_id = "cfba17a6-58b8-4595-afb9-3c9e4e169a14"
     response = client.delete(
         f"/recommendation/recommendations/{false_id}",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ core_data: models_core.CoreData
 
 
 @pytest_asyncio.fixture(scope="module", autouse=True)
-async def init_objects():
+async def init_objects() -> None:
     global core_data
 
     core_data = models_core.CoreData(
@@ -66,7 +66,7 @@ async def init_objects():
     await add_object_to_db(core_data)
 
 
-async def test_save_file():
+async def test_save_file() -> None:
     valid_uuid = str(uuid.uuid4())
     with Path("assets/images/default_profile_picture.png").open("rb") as file:
         await save_file_as_data(
@@ -80,7 +80,7 @@ async def test_save_file():
         )
 
 
-async def test_save_file_with_invalid_content_type():
+async def test_save_file_with_invalid_content_type() -> None:
     valid_uuid = str(uuid.uuid4())
     with (
         pytest.raises(HTTPException, match="400: Invalid file format, supported*"),
@@ -97,7 +97,7 @@ async def test_save_file_with_invalid_content_type():
         )
 
 
-async def test_save_file_raise_a_value_error_if_filename_isnt_an_uuid():
+async def test_save_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with (
         pytest.raises(ValueError, match="The filename is not a valid UUID"),
@@ -111,7 +111,7 @@ async def test_save_file_raise_a_value_error_if_filename_isnt_an_uuid():
         )
 
 
-async def test_save_bytes():
+async def test_save_bytes() -> None:
     valid_uuid = str(uuid.uuid4())
     with Path("assets/images/default_profile_picture.png").open("rb") as file:
         await save_bytes_as_data(
@@ -123,7 +123,7 @@ async def test_save_bytes():
         )
 
 
-async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid():
+async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with (
         pytest.raises(ValueError, match="The filename is not a valid UUID"),
@@ -138,7 +138,7 @@ async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid():
         )
 
 
-def test_get_existing_file_path_with_valid_uuid():
+def test_get_existing_file_path_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
     file_path = Path(f"data/test/{valid_uuid}.png")
@@ -154,7 +154,7 @@ def test_get_existing_file_path_with_valid_uuid():
     assert returned_path == file_path
 
 
-def test_get_non_existing_file_path_with_valid_uuid_return_default_asset():
+def test_get_non_existing_file_path_with_valid_uuid_return_default_asset() -> None:
     valid_uuid = str(uuid.uuid4())
     path = get_file_path_from_data(
         directory="test",
@@ -164,7 +164,7 @@ def test_get_non_existing_file_path_with_valid_uuid_return_default_asset():
     assert path == Path("assets/images/default_profile_picture.png")
 
 
-def test_get_file_path_raise_a_value_error_if_filename_isnt_an_uuid():
+def test_get_file_path_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(ValueError, match="The filename is not a valid UUID"):
         get_file_path_from_data(
@@ -174,7 +174,7 @@ def test_get_file_path_raise_a_value_error_if_filename_isnt_an_uuid():
         )
 
 
-def test_get_file_with_valid_uuid():
+def test_get_file_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
     file = get_file_from_data(
@@ -185,7 +185,7 @@ def test_get_file_with_valid_uuid():
     assert file.path == Path(default_asset)
 
 
-def test_get_file_raise_a_value_error_if_filename_isnt_an_uuid():
+def test_get_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(ValueError, match="The filename is not a valid UUID"):
         get_file_from_data(
@@ -195,7 +195,7 @@ def test_get_file_raise_a_value_error_if_filename_isnt_an_uuid():
         )
 
 
-def test_delete_file_with_valid_uuid():
+def test_delete_file_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
     file_png_path = Path(f"data/test/{valid_uuid}.png")
@@ -218,7 +218,7 @@ def test_delete_file_with_valid_uuid():
     assert not Path(file_jpg_path).is_file()
 
 
-def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid():
+def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(ValueError, match="The filename is not a valid UUID"):
         delete_file_from_data(
@@ -227,7 +227,7 @@ def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid():
         )
 
 
-async def test_save_pdf_first_page_as_image():
+async def test_save_pdf_first_page_as_image() -> None:
     valid_uuid = str(uuid.uuid4())
 
     await save_pdf_first_page_as_image(
@@ -240,14 +240,14 @@ async def test_save_pdf_first_page_as_image():
     assert Path(f"data/test/image/{valid_uuid}.jpg").is_file()
 
 
-async def test_get_core_data():
+async def test_get_core_data() -> None:
     async with TestingSessionLocal() as db:
         exemple_core_data = await get_core_data(core_data_class=ExempleCoreData, db=db)
         assert exemple_core_data.name == "Fabristpp"
         assert exemple_core_data.age == 42
 
 
-async def test_get_default_core_data():
+async def test_get_default_core_data() -> None:
     async with TestingSessionLocal() as db:
         default_core_data = await get_core_data(
             core_data_class=ExempleDefaultCoreData,
@@ -266,7 +266,7 @@ async def test_get_default_without_default_values_core_data():
             )
 
 
-async def test_replace_core_data():
+async def test_replace_core_data() -> None:
     async with TestingSessionLocal() as db:
         core_data = ExempleExistingCoreData(
             name="ECLAIR",


### PR DESCRIPTION
### Description

Fix #403 

Add Postgresql databse support for tests. Use a TestAppClient per test file, to prevent tests from a module to impact other modules

Configure a Postgresql database for the test workflow.
Run tests with Postgresql. Run migration tests with SQLite and Postgresql.

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the documentation, if necessary
