### PR TITLE
Add ContentHTTPException and AuthHTTPException

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -29,6 +29,7 @@ from app.core.groups.groups_type import GroupType
 from app.core.log import LogConfig
 from app.dependencies import get_db_engine, get_redis_client, get_settings
 from app.modules.module_list import module_list
+from app.types.exceptions import ContentHTTPException
 from app.types.sqlalchemy import Base
 from app.utils import initialization
 from app.utils.redis import limiter
@@ -385,6 +386,17 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
+        )
+
+    @app.exception_handler(ContentHTTPException)
+    async def auth_exception_handler(
+        request: Request,
+        exc: ContentHTTPException,
+    ):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=jsonable_encoder(exc.content),
+            headers=exc.headers,
         )
 
     return app

--- a/app/types/exceptions.py
+++ b/app/types/exceptions.py
@@ -55,5 +55,7 @@ class AuthHTTPException(ContentHTTPException):
         }
 
         super().__init__(status_code=status_code, content=content)
+
+
 class PaymentToolCredentialsNotSetException(Exception):
     pass

--- a/app/types/exceptions.py
+++ b/app/types/exceptions.py
@@ -1,6 +1,59 @@
+from typing import Any
+
+from fastapi import HTTPException
+
+
 class CoreDataNotFoundException(Exception):
     pass
 
 
+class ContentHTTPException(HTTPException):
+    """
+    A custom HTTPException allowing to return custom content.
+
+    Instead of returning `{detail: <content>}`, this exception can return a json serialized `<content>`.
+
+    You need to define a custom exception handler to use it:
+    ```python
+    @app.exception_handler(ContentHTTPException)
+    async def auth_exception_handler(
+        request: Request,
+        exc: ContentHTTPException,
+    ):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=jsonable_encoder(exc.content),
+            headers=exc.headers,
+        )
+    ```
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        content: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=content, headers=headers)
+        self.content = content
+
+
+class AuthHTTPException(ContentHTTPException):
+    """
+    A custom HTTPException used for OIDC or OAuth error responses
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        error: str,
+        error_description: str,
+    ) -> None:
+        content = {
+            "error": error,
+            "error_description": error_description,
+        }
+
+        super().__init__(status_code=status_code, content=content)
 class PaymentToolCredentialsNotSetException(Exception):
     pass


### PR DESCRIPTION
to be able to raise custom errors instead of returning generic JSONResponse.

This change allows us to treat them as other `HTTPExceptions` in handlers and openapi schema