### PR TITLE
Use fastapi_responses to include raised Exceptions in the openapi file

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -16,6 +16,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
+from fastapi_responses import custom_openapi
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -257,6 +258,9 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
     )
     app.include_router(api.api_router)
     use_route_path_as_operation_ids(app)
+
+    # We use fastapi_responses to include raised Exceptions in the openapi file
+    app.openapi = custom_openapi(app)
 
     app.add_middleware(
         CORSMiddleware,

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -2,6 +2,7 @@ aiofiles==23.2.1                    # Asynchronous file manipulation
 alembic==1.13.1                     # database migrations
 asyncpg==0.29.0                     # PostgreSQL adapter for asynchronous operations
 bcrypt==4.1.3                       # password hashing
+fastapi-responses @ git+https://github.com/armanddidierjean/fastapi-responses
 fastapi==0.110.3
 firebase-admin==6.5.0               # Firebase is used for push notification
 icalendar==5.0.12


### PR DESCRIPTION
### Description

<img width="711" alt="Capture d’écran 2024-06-02 à 18 07 07" src="https://github.com/aeecleclair/Hyperion/assets/95971503/430efabc-04dc-4390-9244-9b78c2fdea39">

### Notes
 - currently fastapi_responses does not support discovering custom HTTPExceptions (like `ContentException` from #458)
 - the last fastapi_responses version has a bug which may create an infinite loop, this happens with `/auth/token`
 - only one exception can be included per status_code. This means that if an endpoint raise both `HTTPException(404, "first error")` and `HTTPException(404, "second error")`, only one of them will be included in the openapi schema
 
### Checklist

- [x] All tests passing
- [x] Extended the documentation, if necessary
