### PR TITLE
Fix loggers and db initialization when using multiple Gunicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 # Image running several instances of uvicorn in parallel with gunicorn, listens on port 80
 # See https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 
-COPY ./gunicorn.conf.py /app/gunicorn.conf.py
+# Gunicorn config file must be named `gunicorn_conf.py` to be used by `uvicorn-gunicorn-fastapi`
+# See https://github.com/tiangolo/uvicorn-gunicorn-docker?tab=readme-ov-file#gunicorn_conf
+COPY ./gunicorn.conf.py /app/gunicorn_conf.py
 
 COPY ./alembic.ini /app/alembic.ini
 COPY ./migrations /app/migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 # Image running several instances of uvicorn in parallel with gunicorn, listens on port 80
 # See https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
 
+COPY ./gunicorn.conf.py /app/gunicorn.conf.py
+
 COPY ./alembic.ini /app/alembic.ini
 COPY ./migrations /app/migrations
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ To enable the service:
 
 ## Running Hyperion with Gunicorn
 
-For production we encourage to run Hyperion with multiple Gunicorn workers. You can use our [docker image](./Dockerfile) and [docker-compose file](./docker-compose.yaml) files to run Hyperion with Gunicorn.
+For production we encourage to use Gunicorn to run and manage multiple Uvicorn workers. You can use our [docker image](./Dockerfile) and [docker-compose file](./docker-compose.yaml) files to run Hyperion with Gunicorn. See [Gunicorn with Uvicorn](https://fastapi.tiangolo.com/deployment/server-workers/#gunicorn-with-uvicorn-workers) FastAPI documentation.
 
 Do not use gunicorn `--preload` flag. It initialise a first Hyperion instance then fork it to create workers. This is not compatible with the way we handle loggers in their own thread.
 

--- a/README.md
+++ b/README.md
@@ -200,3 +200,13 @@ To enable the service:
    1. Go to [Google cloud, IAM and administration, Service account](https://console.cloud.google.com/iam-admin/serviceaccounts) and add a new Service Account with Messaging API capabilities.
    2. Choose _Manage keys_ and create a new JSON key.
    3. Rename the file `firebase.json` and add it at Hyperion root
+
+---
+
+## Running Hyperion with Gunicorn
+
+For production we encourage to run Hyperion with multiple Gunicorn workers. You can use our [docker image](./Dockerfile) and [docker-compose file](./docker-compose.yaml) files to run Hyperion with Gunicorn.
+
+Do not use gunicorn `--preload` flag. It initialise a first Hyperion instance then fork it to create workers. This is not compatible with the way we handle loggers in their own thread.
+
+You should use our [Gunicorn configuration file](./gunicorn_conf.py) to ensure that database initialization and migrations are only run once.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -176,6 +176,11 @@ class Settings(BaseSettings):
     # Automatically generated parameters #
     ######################################
 
+    # If Hyperion should initialize the database on startup
+    # This environment variable is set by the Gunicorn on_starting hook, to tell the workers to avoid initializing the database
+    # You don't want to set this variable manually
+    HYPERION_INIT_DB: bool = True
+
     # The following properties can not be instantiated as class variables as them need to be computed using another property from the class,
     # which won't be available before the .env file parsing.
     # We thus decide to use the decorator `@property` to make these methods usable as properties and not functions: as properties: Settings.RSA_PRIVATE_KEY, Settings.RSA_PUBLIC_KEY and Settings.RSA_PUBLIC_JWK
@@ -325,3 +330,10 @@ class Settings(BaseSettings):
         self.RSA_PUBLIC_JWK  # noqa
 
         return self
+
+
+def construct_prod_settings() -> Settings:
+    """
+    Return the production settings
+    """
+    return Settings(_env_file=".env")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     1. An environment variable
     2. The dotenv .env file
 
-    See [Pydantic Settings documentation](https://pydantic-docs.helpmanual.io/usage/settings/#dotenv-env-support) for more information.
+    See [Pydantic Settings documentation](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support) for more information.
     See [FastAPI settings](https://fastapi.tiangolo.com/advanced/settings/) article for best practices with settings.
 
     To access these settings, the `get_settings` dependency should be used.
@@ -118,11 +118,6 @@ class Settings(BaseSettings):
     # By default, only production's records are logged
     LOG_DEBUG_MESSAGES: bool | None
 
-    # Hyperion follows Semantic Versioning
-    # https://semver.org/
-    HYPERION_VERSION: str = "2.6.0"
-    MINIMAL_TITAN_VERSION_CODE: int = 113
-
     # Origins for the CORS middleware. `["http://localhost"]` can be used for development.
     # See https://fastapi.tiangolo.com/tutorial/cors/
     # It should begin with 'http://' or 'https:// and should never end with a '/'
@@ -167,6 +162,15 @@ class Settings(BaseSettings):
     # Ex: AUTH_CLIENTS=[["Nextcloudclient", "supersecret", "https://mynextcloud.instance/", "NextcloudAuthClient"], ["Piwigo", "secret2", "https://mypiwigo.instance/", "BaseAuthClient"], ["mobileapp", null, "https://titan/", "BaseAuthClient"]]
     # NOTE: AUTH_CLIENTS property should never be used in the code. To get an auth client, use `KNOWN_AUTH_CLIENTS`
     AUTH_CLIENTS: list[tuple[str, str | None, list[str], str]]
+
+    #################################
+    # Hardcoded Hyperion parameters #
+    #################################
+
+    # Hyperion follows Semantic Versioning
+    # https://semver.org/
+    HYPERION_VERSION: str = "2.6.0"
+    MINIMAL_TITAN_VERSION_CODE: int = 113
 
     ######################################
     # Automatically generated parameters #

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -26,14 +26,17 @@ from sqlalchemy.ext.asyncio import (
 
 from app.core import models_core, security
 from app.core.auth import schemas_auth
-from app.core.config import Settings
+from app.core.config import Settings, construct_prod_settings
 from app.core.groups.groups_type import GroupType, get_ecl_groups
 from app.core.payment.payment_tool import PaymentTool
 from app.core.users import cruds_users
 from app.types.scopes_type import ScopeType
 from app.utils.communication.notifications import NotificationManager, NotificationTool
 from app.utils.redis import connect
-from app.utils.tools import is_user_external, is_user_member_of_an_allowed_group
+from app.utils.tools import (
+    is_user_external,
+    is_user_member_of_an_allowed_group,
+)
 
 # We could maybe use hyperion.security
 hyperion_access_logger = logging.getLogger("hyperion.access")
@@ -131,7 +134,7 @@ def get_settings() -> Settings:
     """
     # `lru_cache()` decorator is here to prevent the class to be instantiated multiple times.
     # See https://fastapi.tiangolo.com/advanced/settings/#lru_cache-technical-details
-    return Settings(_env_file=".env")
+    return construct_prod_settings()
 
 
 def get_redis_client(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,8 +37,6 @@ services:
         condition: service_healthy
       hyperion-redis:
         condition: service_started
-    environment:
-      - GUNICORN_CMD_ARGS="--preload"
     ports:
       - 8000:80
     volumes:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,34 @@
+import logging
+import os
+
+from gunicorn.arbiter import Arbiter
+
+from app.app import init_db
+from app.core.config import construct_prod_settings
+from app.core.log import LogConfig
+
+
+def on_starting(server: Arbiter):
+    # We call `construct_prod_settings()` and not the dependency `get_settings()` because:
+    # - we know we want to use the production settings
+    # - we will edit environment variables to avoid initializing the database and `get_settings()` is a cached function
+    settings = construct_prod_settings()
+
+    # We set an environment variable to tell workers to avoid initializing the database
+    # as we want to do it only once before workers are forked from the arbiter
+    os.environ["HYPERION_INIT_DB"] = "False"
+
+    # Initialize loggers
+    LogConfig().initialize_loggers(settings=settings)
+
+    hyperion_error_logger = logging.getLogger("hyperion.error")
+
+    hyperion_error_logger.warning(
+        "Starting Gunicorn server and initializing the database.",
+    )
+
+    init_db(
+        settings=settings,
+        hyperion_error_logger=hyperion_error_logger,
+        drop_db=False,
+    )

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,9 +1,62 @@
 import logging
+import multiprocessing
 import os
 
 from app.app import init_db
 from app.core.config import construct_prod_settings
 from app.core.log import LogConfig
+
+# This gunicorn configuration file is based on [`uvicorn-gunicorn-docker` image config file](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/gunicorn_conf.py)
+# It define an `on_starting` hook that instantiate the database and run migrations
+
+# For usage with uvicorn-gunicorn-docker image see:
+# https://github.com/tiangolo/uvicorn-gunicorn-docker?tab=readme-ov-file#gunicorn_conf
+
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+max_workers_str = os.getenv("MAX_WORKERS")
+use_max_workers = None
+if max_workers_str:
+    use_max_workers = int(max_workers_str)
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:  # noqa: SIM108
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0  # noqa: S101
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+    if use_max_workers:
+        web_concurrency = min(web_concurrency, use_max_workers)
+accesslog_var = os.getenv("ACCESS_LOG", "-")
+use_accesslog = accesslog_var or None
+errorlog_var = os.getenv("ERROR_LOG", "-")
+use_errorlog = errorlog_var or None
+graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
+timeout_str = os.getenv("TIMEOUT", "120")
+keepalive_str = os.getenv("KEEP_ALIVE", "5")
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+errorlog = use_errorlog
+worker_tmp_dir = "/dev/shm"  # noqa: S108
+accesslog = use_accesslog
+graceful_timeout = int(graceful_timeout_str)
+timeout = int(timeout_str)
+keepalive = int(keepalive_str)
 
 
 def on_starting(server) -> None:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,14 +1,19 @@
 import logging
 import os
 
-from gunicorn.arbiter import Arbiter
-
 from app.app import init_db
 from app.core.config import construct_prod_settings
 from app.core.log import LogConfig
 
 
-def on_starting(server: Arbiter):
+def on_starting(server) -> None:
+    """
+    The hook is called just before the master process is initialized. We use it to instantiate the database and run migrations
+
+    An gunicorn.arbiter.Arbiter instance is passed as an argument.
+
+    See https://docs.gunicorn.org/en/stable/settings.html#on-starting
+    """
     # We call `construct_prod_settings()` and not the dependency `get_settings()` because:
     # - we know we want to use the production settings
     # - we will edit environment variables to avoid initializing the database and `get_settings()` is a cached function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,9 @@ disallow_any_generics = false
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
-module = ["firebase_admin", "icalendar", "fitz"]
+# Tracking issues
+# Gunicorn : https://github.com/benoitc/gunicorn/issues/2833
+module = ["firebase_admin", "icalendar", "fitz", "gunicorn.arbiter"]
 ignore_missing_imports = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,7 @@ disallow_any_generics = false
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
-# Tracking issues
-# Gunicorn : https://github.com/benoitc/gunicorn/issues/2833
-module = ["firebase_admin", "icalendar", "fitz", "gunicorn.arbiter"]
+module = ["firebase_admin", "icalendar", "fitz"]
 ignore_missing_imports = true
 
 


### PR DESCRIPTION
### Description

- disable default Gunicorn logger handlers to use our custom loggers
- remove `--preload` flag which break our async Queue logger handlers
- allow to prevent db init on Hyperion startup using an env variable
- add a Gunicorn on_starting hook to init the db

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the documentation, if necessary
