### PR TITLE
Bump ruff to version 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 # Allow `assert` and hardcoded passwords for tests.
-"tests/*" = ["S101", "S105", "S106", "ASYNC101"]
+"tests/*" = ["S101", "S105", "S106", "ASYNC230"]
 # Allow endpoints, tools and dependencies to raise `HTTPException` after catching an excetion without reraising (`from err`)
 "**/endpoints_*" = ["B904"]
 "**/cruds_*" = ["B904"]          # TODO: find a better way to handle cruds errors

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-asyncio==0.23.7
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest==8.2.2
-ruff==0.4.8
+ruff==0.5.2
 types-aiofiles==24.1.0.20240626
 types-redis==4.6.0.20240425
 types-requests==2.32.0.20240622


### PR DESCRIPTION
See the split of rule ASYN101 in [version 5.0.0](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#050)