### PR TITLE
Init db engine on Hyperion launch

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -27,7 +27,10 @@ from app.core import models_core
 from app.core.config import Settings
 from app.core.groups.groups_type import GroupType
 from app.core.log import LogConfig
-from app.dependencies import get_redis_client
+from app.dependencies import (
+    get_redis_client,
+    init_and_get_db_engine,
+)
 from app.modules.module_list import module_list
 from app.types.exceptions import ContentHTTPException
 from app.types.sqlalchemy import Base
@@ -343,6 +346,9 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
         settings=settings,
     ):
         hyperion_error_logger.info("Redis client not configured")
+
+    # We need to init the database engine to be able to use it in dependencies
+    init_and_get_db_engine(settings)
 
     @app.middleware("http")
     async def logging_middleware(

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -71,7 +71,7 @@ async def get_request_id(request: Request) -> str:
     return request_id
 
 
-def get_db_engine(settings: Settings) -> AsyncEngine:
+def init_and_get_db_engine(settings: Settings) -> AsyncEngine:
     """
     Return the (asynchronous) database engine, if the engine doesn't exit yet it will create one based on the settings
     """
@@ -93,19 +93,6 @@ def get_db_engine(settings: Settings) -> AsyncEngine:
             expire_on_commit=False,
         )
     return engine
-
-
-def get_session_maker() -> Callable[[], AsyncSession]:
-    """
-    Return the session maker
-    """
-    if SessionLocal is None:
-        hyperion_error_logger.error("Database engine is not initialized")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Database engine is not initialized",
-        )
-    return SessionLocal
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -6,7 +6,7 @@ from alembic import context
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from app.dependencies import get_db_engine, get_settings
+from app.dependencies import get_settings, init_and_get_db_engine
 from app.types.sqlalchemy import Base
 
 # this is the Alembic Config object, which provides
@@ -88,7 +88,7 @@ async def create_async_engine_and_run_async_migrations() -> None:
     # As we want to use the production database, we can call the `get_settings` function directly
     # instead of using it as a dependency (`app.dependency_overrides.get(get_settings, get_settings)()`)
     settings = get_settings()
-    connectable = get_db_engine(settings)
+    connectable = init_and_get_db_engine(settings)
 
     async with connectable.connect() as connection:
         await run_async_migrations(connection)


### PR DESCRIPTION
to prevent an error `Database engine is not initialized`