### PR TITLE
Raise ValueError in phone validator

### DIFF
--- a/app/types/exceptions.py
+++ b/app/types/exceptions.py
@@ -126,8 +126,3 @@ class UserWithEmailAlreadyExistError(Exception):
         super().__init__(
             f"An account with the email {email} already exist",
         )
-
-
-class PhoneNumberValidationError(Exception):
-    def __init__(self):
-        super().__init__("The phone number is not valid")

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -5,8 +5,6 @@ See https://pydantic-docs.helpmanual.io/usage/validators/#reuse-validators
 
 import phonenumbers
 
-from app.types.exceptions import PhoneNumberValidationError
-
 
 def password_validator(password: str) -> str:
     """

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -26,11 +26,16 @@ def phone_formatter(phone: str) -> str:
     This function is intended to be used as a Pydantic validator:
     https://pydantic-docs.helpmanual.io/usage/validators/#reuse-validators
     """
-    parsed_phone = phonenumbers.parse(phone, None)
+
+    # We need to raise a ValueError for Pydantic to catch it and return an error response
+    try:
+        parsed_phone = phonenumbers.parse(phone, None)
+    except Exception as error:
+        raise ValueError(f"Invalid phone number: {error}")  # noqa: B904, TRY003
     if not phonenumbers.is_possible_number(parsed_phone):
-        raise PhoneNumberValidationError
+        raise ValueError("Invalid phone number, number is not possible")  # noqa: TRY003
     if not phonenumbers.is_valid_number(parsed_phone):
-        raise PhoneNumberValidationError
+        raise ValueError("Invalid phone number, number is not valid")  # noqa: TRY003
     return phonenumbers.format_number(parsed_phone, phonenumbers.PhoneNumberFormat.E164)
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -177,6 +177,36 @@ def test_create_and_activate_user(mocker: MockerFixture, client: TestClient) -> 
     assert response.status_code == 201
 
 
+@pytest.mark.parametrize(
+    ("email", "expected_error"),
+    [
+        (
+            "123456789",
+            "Value error, Invalid phone number: (0) Missing or invalid default region.",
+        ),
+        ("+3300000000000", "Value error, Invalid phone number, number is not possible"),
+        ("+33000000000", "Value error, Invalid phone number, number is not valid"),
+    ],
+)
+def activate_user_with_invalid_phone_number(
+    phone: str,
+    expected_error: str,
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/users/activate",
+        json={
+            "activation_token": UNIQUE_TOKEN,
+            "password": "password",
+            "firstname": "firstname",
+            "name": "name",
+            "phone": phone,
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["msg"] == expected_error
+
+
 def test_update_batch_create_users(client: TestClient) -> None:
     student = "39691052-2ae5-4e12-99d0-7a9f5f2b0136"
     response = client.post(


### PR DESCRIPTION
to let FastAPI return Pydantic ValidationError instead of crashing

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the documentation, if necessary
