### PR TITLE
RAID: Generate PDF

### DIFF
--- a/app/modules/raid/endpoints_raid.py
+++ b/app/modules/raid/endpoints_raid.py
@@ -265,6 +265,31 @@ async def create_team(
     return created_team
 
 
+@module.router.post(
+    "/raid/teams/generate-pdf",
+    status_code=204,
+)
+async def generate_teams_pdf(
+    user: models_core.CoreUser = Depends(is_user_a_member_of(GroupType.raid_admin)),
+    db: AsyncSession = Depends(get_db),
+    drive_file_manager: DriveFileManager = Depends(get_drive_file_manager),
+    settings: Settings = Depends(get_settings),
+):
+    """
+    PDF are automatically generated when a team is created or updated.
+    This endpoint is used to regenerate all the PDFs.
+    """
+    teams = await cruds_raid.get_all_teams(db)
+
+    for team in teams:
+        await post_update_actions(
+            team,
+            db,
+            drive_file_manager,
+            settings=settings,
+        )
+
+
 @module.router.get(
     "/raid/participants/{participant_id}/team",
     response_model=schemas_raid.Team,

--- a/tests/test_raid.py
+++ b/tests/test_raid.py
@@ -235,6 +235,14 @@ def test_create_team(client: TestClient):
     assert response.json()["name"] == "New Team"
 
 
+def test_generate_teams_pdf(client: TestClient):
+    response = client.post(
+        "/raid/teams/generate-pdf",
+        headers={"Authorization": f"Bearer {token_raid_admin}"},
+    )
+    assert response.status_code == 204
+
+
 def test_get_team_by_participant_id(client: TestClient):
     response = client.get(
         f"/raid/participants/{simple_user.id}/team",


### PR DESCRIPTION
### Description

Allow to force the generation of all teams pdf

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the documentation, if necessary
