### PR TITLE
Rename lintandformat workflow

### DIFF
--- a/.github/workflows/lintandformat.yml
+++ b/.github/workflows/lintandformat.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, edited, ready_for_review, synchronize]
 
 jobs:
-  test:
+  lintandformat:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
instead of having two workflows named test


