### PR TITLE
Flappybird security

### DIFF
--- a/app/modules/flappybird/endpoints_flappybird.py
+++ b/app/modules/flappybird/endpoints_flappybird.py
@@ -6,8 +6,8 @@ from fastapi import Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import models_core
-from app.core.groups.groups_type import GroupType
-from app.dependencies import get_db, is_user_a_member, is_user_a_member_of
+from app.core.groups.groups_type import AccountType, GroupType
+from app.dependencies import get_db, is_user_a_member, is_user_in
 from app.modules.flappybird import (
     cruds_flappybird,
     models_flappybird,
@@ -24,11 +24,10 @@ def genKey(score: int) -> int:
     
     return key
 
-
 module = Module(
     root="flappybird",
     tag="Flappy Bird",
-    default_allowed_groups_ids=[GroupType.student],
+    default_allowed_account_types=[AccountType.student],
 )
 
 
@@ -146,6 +145,6 @@ async def create_flappybird_score(
 async def remove_flappybird_score(
     targeted_user_id: str,
     db: AsyncSession = Depends(get_db),
-    user: models_core.CoreUser = Depends(is_user_a_member_of(GroupType.admin)),
+    user: models_core.CoreUser = Depends(is_user_in(GroupType.admin)),
 ):
     await cruds_flappybird.delete_flappybird_best_score(db=db, user_id=targeted_user_id)

--- a/app/modules/flappybird/models_flappybird.py
+++ b/app/modules/flappybird/models_flappybird.py
@@ -14,6 +14,7 @@ class FlappyBirdScore(Base):
     user_id: Mapped[str] = mapped_column(ForeignKey("core_user.id"))
     user: Mapped[CoreUser] = relationship("CoreUser", init=False)
     value: Mapped[int]
+    key: Mapped[int]
     creation_time: Mapped[datetime]
 
 
@@ -24,4 +25,5 @@ class FlappyBirdBestScore(Base):
     user_id: Mapped[str] = mapped_column(ForeignKey("core_user.id"))
     user: Mapped[CoreUser] = relationship("CoreUser", init=False)
     value: Mapped[int]
+    key: Mapped[int]
     creation_time: Mapped[datetime]

--- a/app/modules/flappybird/schemas_flappybird.py
+++ b/app/modules/flappybird/schemas_flappybird.py
@@ -8,6 +8,7 @@ from app.core.schemas_core import CoreUserSimple
 
 class FlappyBirdScoreBase(BaseModel):
     value: int
+    key: int
 
 
 class FlappyBirdScore(FlappyBirdScoreBase):


### PR DESCRIPTION
Add security for score submission with key verification in flappybird

Previously, intercepting requests allowed users to modify scores. 
Now, an additional security layer with a key mechanism ensures 
scores cannot be modified with during transmission.

This commit goes hand-in-hand with the related changes in Titan.