### PR TITLE
APIToolAuthClient: Allow to pass pkce parameters with client secret

### DIFF
--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -125,6 +125,7 @@ class APIToolAuthClient(BaseAuthClient):
     """
 
     allowed_scopes: set[ScopeType | str] = {ScopeType.API}
+    allow_pkce_with_client_secret: bool = True
 
 
 class NextcloudAuthClient(BaseAuthClient):


### PR DESCRIPTION
### Description

Postman and Swagger now always pass PKCE parameters in auth request using a client secret