### PR TITLE
Fix attempt: run "expected" workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL Advanced"
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, synchronize]
+  push:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          build-mode: ${{ matrix.build-mode }}
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,16 +28,6 @@ jobs:
         with:
           languages: python
           build-mode: ${{ matrix.build-mode }}
-      - if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:


### PR DESCRIPTION
### Problem

* No PR can be merged, unless an admin makes use of his power to bypass the requirements.
* Because *Analyze (python)* and *CodeQL* are stuck as "pending checks", since:
  * They are expected to run
  * They don't run: the default config (overridden by this YAML) made CodeQL be triggered only on push main

### What we want

* We want those workflows to be triggered on PRs like *lint and format* and *test*.
* I open a PR so that this YAML can be reviewed.