### PR TITLE
Move versions declaration in pyproject.toml

### DIFF
--- a/app/core/utils/config.py
+++ b/app/core/utils/config.py
@@ -1,4 +1,6 @@
+import tomllib
 from functools import cached_property
+from pathlib import Path
 from typing import Any
 
 import jwt
@@ -14,6 +16,11 @@ from app.types.exceptions import (
     InvalidRSAKeyInDotenvError,
 )
 from app.utils.auth import providers
+
+with Path("pyproject.toml").open("rb") as pyproject_binary:
+    pyproject = tomllib.load(pyproject_binary)
+    HYPERION_VERSION: str = pyproject["project"]["version"]
+    MINIMAL_TITAN_VERSION_CODE: int = pyproject["project"]["minimal-titan-version-code"]
 
 
 class Settings(BaseSettings):
@@ -186,14 +193,13 @@ class Settings(BaseSettings):
     # NOTE: AUTH_CLIENTS property should never be used in the code. To get an auth client, use `KNOWN_AUTH_CLIENTS`
     AUTH_CLIENTS: list[tuple[str, str | None, list[str], str]]
 
-    #################################
-    # Hardcoded Hyperion parameters #
-    #################################
+    #############################
+    # pyproject.toml parameters #
+    #############################
 
-    # Hyperion follows Semantic Versioning
-    # https://semver.org/
-    HYPERION_VERSION: str = "4.3.3"
-    MINIMAL_TITAN_VERSION_CODE: int = 139
+    # Version parameters
+    HYPERION_VERSION: str = HYPERION_VERSION
+    MINIMAL_TITAN_VERSION_CODE: int = MINIMAL_TITAN_VERSION_CODE
 
     ######################################
     # Automatically generated parameters #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
+[project]
+name = "hyperion"
+description = "Back-end of MyECL, the app of the students of École Centrale de Lyon, made by ÉCLAIR"
+readme = "README.md"
+authors = [{ name = "AEECL ECLAIR" }]
+
+# Hyperion follows Semantic Versioning
+# https://semver.org/
+version = "4.3.3"
+minimal-titan-version-code = 139
+requires-python = ">= 3.11, < 3.13"
+
+license = "MIT"
+license-files = ["LICENSE", "assets/privacy.txt", "assets/terms-and-conditions.txt"]
+
+
 [tool.ruff]
 # By default ruff also respect gitignore files
 # Same as Black.


### PR DESCRIPTION
### Why

* Inspired by https://github.com/aeecleclair/Titan/pull/480
* Now both the version of itself and of the Titan client are declared in the TOML config file

### How

* I tried cleverly adding [`toml_file="pyproject.toml",`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#other-settings-source) in the `SettingsConfigDict` (line 49) so that the model would load fields from both config files (`.env` and `pyproject.toml`), but it seems Pydantic does not allow that at all...
* So I went using Python's *native* [`tomllib`](https://docs.python.org/3/library/tomllib.html) TOML parser : it the only solution that worked for me, and it's short.
  * (The `with` is out of the class because Pydantic started crying about the type of the bytes flow from reading the file)

### [`pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/)

* I just wanted to add
```toml
version = "4.3.3"
minimal-titan-version-code = 139
```
to the `[project]` table, but I realized it **didn't even exist**, so I ended up writing the bare minimum.
* Perhaps we should fill this file seriously...
  * it is powerful for automation and description (it could not hurt to have it filled),
  * and required to make a release on [PyPI](https://pypi.org/user/ECLAIR/) (we already release CalypSSO and the HA wrapper, why not Hyperion itself?).