### PR TITLE
Revoke refresh token on password change

### DIFF
--- a/app/core/auth/cruds_auth.py
+++ b/app/core/auth/cruds_auth.py
@@ -102,7 +102,7 @@ async def revoke_refresh_token_by_client_and_user_id(
     db: AsyncSession,
     client_id: str,
     user_id: str,
-) -> models_auth.RefreshToken | None:
+) -> None:
     """Revoke a refresh token from database"""
 
     await db.execute(
@@ -115,4 +115,3 @@ async def revoke_refresh_token_by_client_and_user_id(
         .values(revoked_on=datetime.now(UTC)),
     )
     await db.commit()
-    return None

--- a/app/core/auth/cruds_auth.py
+++ b/app/core/auth/cruds_auth.py
@@ -115,3 +115,20 @@ async def revoke_refresh_token_by_client_and_user_id(
         .values(revoked_on=datetime.now(UTC)),
     )
     await db.commit()
+
+
+async def revoke_refresh_token_by_user_id(
+    db: AsyncSession,
+    user_id: str,
+) -> None:
+    """Revoke a refresh token from database"""
+
+    await db.execute(
+        update(models_auth.RefreshToken)
+        .where(
+            models_auth.RefreshToken.user_id == user_id,
+            models_auth.RefreshToken.revoked_on.is_(None),
+        )
+        .values(revoked_on=datetime.now(UTC)),
+    )
+    await db.commit()


### PR DESCRIPTION
### Description

Currently, is someone account is compromised, the user can not log out all active sessions.

Due to the use of a JWT we can not revoke active access token, but as they have a limited duration they will automatically expire after some time.

We should revoke refresh token to ensure that clients won't be able to get a new access token.

As a consequence the user changing its password in settings will be logged out of the app, but not immediately, only after the expiration of its refresh token
