### PR TITLE
Unit of work 3: Transactional database: auto-commit or rollback per endpoint

### DIFF
--- a/app/core/auth/cruds_auth.py
+++ b/app/core/auth/cruds_auth.py
@@ -3,7 +3,6 @@
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import models_auth

--- a/app/core/auth/cruds_auth.py
+++ b/app/core/auth/cruds_auth.py
@@ -29,13 +29,8 @@ async def create_authorization_token(
     """Create a new group in database and return it"""
 
     db.add(db_authorization_code)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return db_authorization_code
+    await db.flush()
+    return db_authorization_code
 
 
 async def delete_authorization_token_by_token(
@@ -49,7 +44,7 @@ async def delete_authorization_token_by_token(
             models_auth.AuthorizationCode.code == code,
         ),
     )
-    await db.commit()
+    await db.flush()
     return None
 
 
@@ -71,13 +66,8 @@ async def create_refresh_token(
     """Create a new refresh token in database and return it"""
 
     db.add(db_refresh_token)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return db_refresh_token
+    await db.flush()
+    return db_refresh_token
 
 
 async def revoke_refresh_token_by_token(
@@ -94,7 +84,7 @@ async def revoke_refresh_token_by_token(
         )
         .values(revoked_on=datetime.now(UTC)),
     )
-    await db.commit()
+    await db.flush()
     return None
 
 
@@ -114,7 +104,7 @@ async def revoke_refresh_token_by_client_and_user_id(
         )
         .values(revoked_on=datetime.now(UTC)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def revoke_refresh_token_by_user_id(
@@ -131,4 +121,4 @@ async def revoke_refresh_token_by_user_id(
         )
         .values(revoked_on=datetime.now(UTC)),
     )
-    await db.commit()
+    await db.flush()

--- a/app/core/core_endpoints/cruds_core.py
+++ b/app/core/core_endpoints/cruds_core.py
@@ -87,11 +87,7 @@ async def create_module_group_visibility(
     """Create a new module visibility in database and return it"""
 
     db.add(module_visibility)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def create_module_account_type_visibility(
@@ -101,11 +97,7 @@ async def create_module_account_type_visibility(
     """Create a new module visibility in database and return it"""
 
     db.add(module_visibility)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def delete_module_group_visibility(
@@ -119,7 +111,7 @@ async def delete_module_group_visibility(
             models_core.ModuleGroupVisibility.allowed_group_id == allowed_group_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_module_account_type_visibility(
@@ -134,7 +126,7 @@ async def delete_module_account_type_visibility(
             == allowed_account_type,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_core_data_crud(
@@ -164,13 +156,8 @@ async def add_core_data_crud(
     To manipulate core data, prefer using the `get_core_data` and `set_core_data` utils.
     """
     db.add(core_data)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return core_data
+    await db.flush()
+    return core_data
 
 
 async def delete_core_data_crud(
@@ -182,4 +169,4 @@ async def delete_core_data_crud(
             models_core.CoreData.schema == schema,
         ),
     )
-    await db.commit()
+    await db.flush()

--- a/app/core/core_endpoints/cruds_core.py
+++ b/app/core/core_endpoints/cruds_core.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 from sqlalchemy import delete, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.core_endpoints import models_core

--- a/app/core/google_api/cruds_google_api.py
+++ b/app/core/google_api/cruds_google_api.py
@@ -10,11 +10,7 @@ async def create_oauth_flow_state(
     db: AsyncSession,
 ) -> None:
     db.add(oauth_flow_state)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def get_oauth_flow_state_by_state(

--- a/app/core/google_api/cruds_google_api.py
+++ b/app/core/google_api/cruds_google_api.py
@@ -1,5 +1,4 @@
 from sqlalchemy import delete, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.google_api import models_google_api

--- a/app/core/groups/cruds_groups.py
+++ b/app/core/groups/cruds_groups.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/core/groups/cruds_groups.py
+++ b/app/core/groups/cruds_groups.py
@@ -54,13 +54,8 @@ async def create_group(
     """Create a new group in database and return it"""
 
     db.add(group)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return group
+    await db.flush()
+    return group
 
 
 async def delete_group(db: AsyncSession, group_id: str):
@@ -69,7 +64,7 @@ async def delete_group(db: AsyncSession, group_id: str):
     await db.execute(
         delete(models_groups.CoreGroup).where(models_groups.CoreGroup.id == group_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_membership(
@@ -79,12 +74,8 @@ async def create_membership(
     """Add a user to a group using a membership"""
 
     db.add(membership)
-    try:
-        await db.commit()
-        return await get_group_by_id(db, membership.group_id)
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
+    return await get_group_by_id(db, membership.group_id)
 
 
 async def delete_membership_by_group_id(
@@ -96,7 +87,7 @@ async def delete_membership_by_group_id(
             models_groups.CoreMembership.group_id == group_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_membership_by_group_and_user_id(
@@ -110,7 +101,7 @@ async def delete_membership_by_group_and_user_id(
             models_groups.CoreMembership.user_id == user_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_group(
@@ -123,4 +114,4 @@ async def update_group(
         .where(models_groups.CoreGroup.id == group_id)
         .values(**group_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()

--- a/app/core/memberships/endpoints_memberships.py
+++ b/app/core/memberships/endpoints_memberships.py
@@ -132,11 +132,7 @@ async def create_association_membership(
         db=db,
         membership=db_association_membership,
     )
-    try:
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+    await db.flush()
     return db_association_membership
 
 
@@ -170,13 +166,7 @@ async def update_association_membership(
         membership=membership,
     )
 
-    try:
-        await db.commit()
-    except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to update membership",
-        )
+    await db.flush()
 
 
 @router.delete(
@@ -218,14 +208,6 @@ async def delete_association_membership(
         db=db,
         membership_id=association_membership_id,
     )
-
-    try:
-        await db.commit()
-    except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to delete membership",
-        )
 
 
 @router.get(
@@ -324,13 +306,9 @@ async def create_user_membership(
     await validate_user_new_membership(db_user_membership, db)
 
     cruds_memberships.create_user_membership(db=db, user_membership=db_user_membership)
-    try:
-        await db.commit()
-    except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to create user membership",
-        )
+
+    await db.flush()
+
     return schemas_memberships.UserMembershipComplete(
         **db_user_membership.__dict__,
         user=schemas_users.CoreUserSimple(
@@ -401,11 +379,7 @@ async def add_batch_membership(
                     end_date=detail.end_date,
                 ),
             )
-    try:
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+    await db.flush()
     return unknown_users
 
 
@@ -448,11 +422,7 @@ async def update_user_membership(
         user_membership_edit=user_membership,
     )
 
-    try:
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 @router.delete(
@@ -481,11 +451,3 @@ async def delete_user_membership(
         db=db,
         user_membership_id=membership_id,
     )
-
-    try:
-        await db.commit()
-    except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to delete user membership",
-        )

--- a/app/core/myeclpay/cruds_myeclpay.py
+++ b/app/core/myeclpay/cruds_myeclpay.py
@@ -68,7 +68,6 @@ async def init_structure_manager_transfer(
             confirmation_token=confirmation_token,
         ),
     )
-    await db.commit()
 
 
 async def get_structure_manager_transfer_by_secret(
@@ -196,7 +195,6 @@ async def update_store(
         .where(models_myeclpay.Store.id == store_id)
         .values(**store_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
 
 
 async def delete_store(

--- a/app/core/myeclpay/endpoints_myeclpay.py
+++ b/app/core/myeclpay/endpoints_myeclpay.py
@@ -10,7 +10,6 @@ import calypsso
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.groups.groups_type import GroupType

--- a/app/core/myeclpay/utils_myeclpay.py
+++ b/app/core/myeclpay/utils_myeclpay.py
@@ -98,18 +98,14 @@ async def validate_transfer_callback(
         )
         raise TransferAlreadyConfirmedInCallbackError(checkout_id)
 
-    try:
-        await cruds_myeclpay.confirm_transfer(
-            db=db,
-            transfer_id=transfer.id,
-        )
-        await cruds_myeclpay.increment_wallet_balance(
-            db=db,
-            wallet_id=transfer.wallet_id,
-            amount=paid_amount,
-        )
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+    await cruds_myeclpay.confirm_transfer(
+        db=db,
+        transfer_id=transfer.id,
+    )
+    await cruds_myeclpay.increment_wallet_balance(
+        db=db,
+        wallet_id=transfer.wallet_id,
+        amount=paid_amount,
+    )
+
     hyperion_myeclpay_logger.info(format_transfer_log(transfer))

--- a/app/core/notification/cruds_notification.py
+++ b/app/core/notification/cruds_notification.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from datetime import date
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.notification import models_notification

--- a/app/core/notification/cruds_notification.py
+++ b/app/core/notification/cruds_notification.py
@@ -56,13 +56,8 @@ async def create_firebase_devices(
     """Register a new firebase device in database and return it"""
 
     db.add(firebase_device)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return firebase_device
+    await db.flush()
+    return firebase_device
 
 
 async def delete_firebase_devices(
@@ -75,7 +70,7 @@ async def delete_firebase_devices(
             == firebase_device_token,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def batch_delete_firebase_device_by_token(
@@ -87,7 +82,7 @@ async def batch_delete_firebase_device_by_token(
             models_notification.FirebaseDevice.firebase_device_token.in_(tokens),
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_firebase_devices_register_date(
@@ -103,7 +98,7 @@ async def update_firebase_devices_register_date(
         )
         .values({"register_date": new_register_date}),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_topic_membership(
@@ -111,13 +106,8 @@ async def create_topic_membership(
     db: AsyncSession,
 ) -> models_notification.TopicMembership:
     db.add(topic_membership)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return topic_membership
+    await db.flush()
+    return topic_membership
 
 
 async def delete_topic_membership(
@@ -133,7 +123,7 @@ async def delete_topic_membership(
             == custom_topic.topic_identifier,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_topic_memberships_by_topic(

--- a/app/core/payment/cruds_payment.py
+++ b/app/core/payment/cruds_payment.py
@@ -1,7 +1,6 @@
 import uuid
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/core/payment/cruds_payment.py
+++ b/app/core/payment/cruds_payment.py
@@ -78,13 +78,8 @@ async def create_checkout_payment(
     checkout_payment: models_payment.CheckoutPayment,
 ) -> models_payment.CheckoutPayment:
     db.add(checkout_payment)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return checkout_payment
+    await db.flush()
+    return checkout_payment
 
 
 async def get_checkout_payment_by_hello_asso_payment_id(

--- a/app/core/payment/cruds_payment.py
+++ b/app/core/payment/cruds_payment.py
@@ -13,14 +13,8 @@ async def create_checkout(
     checkout: models_payment.Checkout,
 ) -> models_payment.Checkout:
     db.add(checkout)
-    try:
-        await db.commit()
 
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return checkout
+    return checkout
 
 
 async def get_checkouts(

--- a/app/core/schools/cruds_schools.py
+++ b/app/core/schools/cruds_schools.py
@@ -85,4 +85,4 @@ async def update_school(
         .where(models_schools.CoreSchool.id == school_id)
         .values(**school_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()

--- a/app/core/schools/endpoints_schools.py
+++ b/app/core/schools/endpoints_schools.py
@@ -8,7 +8,6 @@ import re
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.groups.groups_type import AccountType, GroupType

--- a/app/core/users/cruds_users.py
+++ b/app/core/users/cruds_users.py
@@ -159,13 +159,8 @@ async def create_unconfirmed_user(
     """
 
     db.add(user_unconfirmed)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return user_unconfirmed  # TODO Is this useful ?
+    await db.flush()
+    return user_unconfirmed  # TODO Is this useful ?
 
 
 async def get_unconfirmed_user_by_activation_token(
@@ -188,7 +183,7 @@ async def delete_unconfirmed_user_by_email(db: AsyncSession, email: str):
             models_users.CoreUserUnconfirmed.email == email,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_user(
@@ -196,13 +191,8 @@ async def create_user(
     user: models_users.CoreUser,
 ) -> models_users.CoreUser:
     db.add(user)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return user
+    await db.flush()
+    return user
 
 
 async def delete_user(db: AsyncSession, user_id: str):
@@ -211,7 +201,7 @@ async def delete_user(db: AsyncSession, user_id: str):
     await db.execute(
         delete(models_users.CoreUser).where(models_users.CoreUser.id == user_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_user_recover_request(
@@ -219,13 +209,8 @@ async def create_user_recover_request(
     recover_request: models_users.CoreUserRecoverRequest,
 ) -> models_users.CoreUserRecoverRequest:
     db.add(recover_request)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return recover_request
+    await db.flush()
+    return recover_request
 
 
 async def get_recover_request_by_reset_token(
@@ -245,13 +230,8 @@ async def create_email_migration_code(
     db: AsyncSession,
 ) -> models_users.CoreUserEmailMigrationCode:
     db.add(migration_object)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return migration_object
+    await db.flush()
+    return migration_object
 
 
 async def get_email_migration_code_by_token(
@@ -277,7 +257,7 @@ async def delete_email_migration_code_by_token(
             == confirmation_token,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_recover_request_by_email(db: AsyncSession, email: str):
@@ -288,7 +268,7 @@ async def delete_recover_request_by_email(db: AsyncSession, email: str):
             models_users.CoreUserRecoverRequest.email == email,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_user_password_by_id(
@@ -301,7 +281,7 @@ async def update_user_password_by_id(
         .where(models_users.CoreUser.id == user_id)
         .values(password_hash=new_password_hash),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def remove_users_from_school(

--- a/app/core/users/cruds_users.py
+++ b/app/core/users/cruds_users.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, and_, delete, not_, or_, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy_utils import get_referencing_foreign_keys

--- a/app/core/users/endpoints_users.py
+++ b/app/core/users/endpoints_users.py
@@ -17,7 +17,6 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import cruds_auth

--- a/app/core/users/endpoints_users.py
+++ b/app/core/users/endpoints_users.py
@@ -704,27 +704,18 @@ async def migrate_mail_confirm(
         email=migration_object.new_email,
         db=db,
     )
-    try:
-        await cruds_users.update_user(
-            db=db,
-            user_id=migration_object.user_id,
-            user_update=schemas_users.CoreUserUpdateAdmin(
-                email=migration_object.new_email,
-                account_type=account,
-                school_id=new_school_id,
-            ),
-        )
-        await db.commit()
 
-    except Exception as error:
-        await db.rollback()
-        raise HTTPException(status_code=400, detail=str(error))
-    except IntegrityError:
-        await db.rollback()
-        raise HTTPException(
-            status_code=400,
-            detail="Email migration failed due to database integrity error",
-        )
+    await cruds_users.update_user(
+        db=db,
+        user_id=migration_object.user_id,
+        user_update=schemas_users.CoreUserUpdateAdmin(
+            email=migration_object.new_email,
+            account_type=account,
+            school_id=new_school_id,
+        ),
+    )
+
+    await db.flush()
 
     await cruds_users.delete_email_migration_code_by_token(
         confirmation_token=token,
@@ -854,14 +845,6 @@ async def update_current_user(
     """
 
     await cruds_users.update_user(db=db, user_id=user.id, user_update=user_update)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise HTTPException(
-            status_code=400,
-            detail="Update failed due to database integrity error",
-        )
 
 
 @router.post(
@@ -939,14 +922,6 @@ async def update_user(
         raise HTTPException(status_code=404, detail="User not found")
 
     await cruds_users.update_user(db=db, user_id=user_id, user_update=user_update)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise HTTPException(
-            status_code=400,
-            detail="Update failed due to database integrity error",
-        )
 
 
 @router.post(

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -143,6 +143,8 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             raise
         else:
             await db.commit()
+        finally:
+            await db.close()
 
 
 async def get_unsafe_db() -> AsyncGenerator[AsyncSession, None]:

--- a/app/modules/advert/cruds_advert.py
+++ b/app/modules/advert/cruds_advert.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 from sqlalchemy import delete, or_, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.advert import models_advert, schemas_advert

--- a/app/modules/advert/cruds_advert.py
+++ b/app/modules/advert/cruds_advert.py
@@ -41,11 +41,7 @@ async def create_advertiser(
     db: AsyncSession,
 ) -> models_advert.Advertiser:
     db.add(db_advertiser)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
     return db_advertiser
 
 
@@ -59,11 +55,7 @@ async def update_advertiser(
         .where(models_advert.Advertiser.id == advertiser_id)
         .values(**advertiser_update.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def delete_advertiser(advertiser_id: str, db: AsyncSession):
@@ -72,11 +64,7 @@ async def delete_advertiser(advertiser_id: str, db: AsyncSession):
             models_advert.Advertiser.id == advertiser_id,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def get_adverts(db: AsyncSession) -> Sequence[models_advert.Advert]:
@@ -118,11 +106,7 @@ async def create_advert(
     db: AsyncSession,
 ) -> models_advert.Advert:
     db.add(db_advert)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
     return db_advert
 
 
@@ -136,19 +120,11 @@ async def update_advert(
         .where(models_advert.Advert.id == advert_id)
         .values(**advert_update.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def delete_advert(advert_id: str, db: AsyncSession):
     await db.execute(
         delete(models_advert.Advert).where(models_advert.Advert.id == advert_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()

--- a/app/modules/advert/endpoints_advert.py
+++ b/app/modules/advert/endpoints_advert.py
@@ -81,16 +81,13 @@ async def create_advertiser(
             detail="Invalid id, group_manager_id must be a valid group id",
         )
 
-    try:
-        db_advertiser = models_advert.Advertiser(
-            id=str(uuid.uuid4()),
-            name=advertiser.name,
-            group_manager_id=advertiser.group_manager_id,
-        )
+    db_advertiser = models_advert.Advertiser(
+        id=str(uuid.uuid4()),
+        name=advertiser.name,
+        group_manager_id=advertiser.group_manager_id,
+    )
 
-        return await cruds_advert.create_advertiser(db_advertiser=db_advertiser, db=db)
-    except ValueError as error:
-        raise HTTPException(status_code=422, detail=str(error))
+    return await cruds_advert.create_advertiser(db_advertiser=db_advertiser, db=db)
 
 
 @module.router.delete(
@@ -261,10 +258,8 @@ async def create_advert(
         **advert_params,
     )
 
-    try:
-        result = await cruds_advert.create_advert(db_advert=db_advert, db=db)
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
+    result = await cruds_advert.create_advert(db_advert=db_advert, db=db)
+
     message = Message(
         title=f"📣 Annonce - {result.title}",
         content=result.content,

--- a/app/modules/amap/cruds_amap.py
+++ b/app/modules/amap/cruds_amap.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from datetime import date
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import noload, selectinload
 

--- a/app/modules/amap/endpoints_amap.py
+++ b/app/modules/amap/endpoints_amap.py
@@ -279,14 +279,11 @@ async def add_product_to_delivery(
             detail=f"You can't add a product if the delivery is not in creation mode. The current mode is {delivery.status}.",
         )
 
-    try:
-        await cruds_amap.add_product_to_delivery(
-            delivery_id=delivery_id,
-            products_ids=products_ids,
-            db=db,
-        )
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
+    await cruds_amap.add_product_to_delivery(
+        delivery_id=delivery_id,
+        products_ids=products_ids,
+        db=db,
+    )
 
 
 @module.router.delete(
@@ -488,9 +485,6 @@ async def add_order_to_delievery(
         )
         return schemas_amap.OrderReturn(productsdetail=productsret, **orderret.__dict__)
 
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
-
     finally:
         locker_set(redis_client=redis_client, key=redis_key, lock=False)
 
@@ -540,14 +534,11 @@ async def edit_order_from_delivery(
         )
 
     if order.products_ids is None:
-        try:
-            await cruds_amap.edit_order_without_products(
-                order=order,
-                db=db,
-                order_id=order_id,
-            )
-        except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error))
+        await cruds_amap.edit_order_without_products(
+            order=order,
+            db=db,
+            order_id=order_id,
+        )
 
     else:
         if order.products_quantity is None or len(order.products_quantity) != len(
@@ -608,9 +599,6 @@ async def edit_order_from_delivery(
             hyperion_amap_logger.info(
                 f"Edit_order: Order {order_id} has been edited for user {db_order.user_id}. Amount was {previous_amount}€, is now {amount}€. ({request_id})",
             )
-
-        except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error))
 
         finally:
             locker_set(redis_client=redis_client, key=redis_key, lock=False)
@@ -683,9 +671,6 @@ async def remove_order(
             f"Delete_order: Order {order_id} by {order.user_id} was deleted. {amount}€ were refunded. ({request_id})",
         )
         return Response(status_code=204)
-
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
 
     finally:
         locker_set(redis_client=redis_client, key=redis_key, lock=False)
@@ -1024,16 +1009,11 @@ async def edit_information(
             link="",
             description="",
         )
-        try:
-            await cruds_amap.add_information(empty_information, db)
-        except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error))
+
+        await cruds_amap.add_information(empty_information, db)
 
     else:
-        try:
-            await cruds_amap.edit_information(
-                information_update=edit_information,
-                db=db,
-            )
-        except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error))
+        await cruds_amap.edit_information(
+            information_update=edit_information,
+            db=db,
+        )

--- a/app/modules/booking/cruds_booking.py
+++ b/app/modules/booking/cruds_booking.py
@@ -22,13 +22,8 @@ async def create_manager(
     manager: models_booking.Manager,
 ) -> models_booking.Manager:
     db.add(manager)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return manager
+    await db.flush()
+    return manager
 
 
 async def update_manager(
@@ -41,11 +36,7 @@ async def update_manager(
         .where(models_booking.Manager.id == manager_id)
         .values(**manager_update.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def delete_manager(
@@ -55,11 +46,7 @@ async def delete_manager(
     await db.execute(
         delete(models_booking.Manager).where(models_booking.Manager.id == manager_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def get_manager_by_id(
@@ -212,11 +199,7 @@ async def get_booking_by_id(
 async def create_booking(db: AsyncSession, booking: schemas_booking.BookingComplete):
     db_booking = models_booking.Booking(**booking.model_dump())
     db.add(db_booking)
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def edit_booking(
@@ -229,11 +212,7 @@ async def edit_booking(
         .where(models_booking.Booking.id == booking_id)
         .values(**booking.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def confirm_booking(db: AsyncSession, decision: Decision, booking_id: str):
@@ -242,22 +221,14 @@ async def confirm_booking(db: AsyncSession, decision: Decision, booking_id: str)
         .where(models_booking.Booking.id == booking_id)
         .values(decision=decision),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def delete_booking(db: AsyncSession, booking_id: str):
     await db.execute(
         delete(models_booking.Booking).where(models_booking.Booking.id == booking_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def get_room_by_id(db: AsyncSession, room_id: str) -> models_booking.Room:
@@ -276,13 +247,8 @@ async def get_rooms(db: AsyncSession) -> Sequence[models_booking.Room]:
 
 async def create_room(db: AsyncSession, room: models_booking.Room):
     db.add(room)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return room
+    await db.flush()
+    return room
 
 
 async def edit_room(db: AsyncSession, room_id: str, room: schemas_booking.RoomBase):
@@ -291,11 +257,7 @@ async def edit_room(db: AsyncSession, room_id: str, room: schemas_booking.RoomBa
         .where(models_booking.Room.id == room_id)
         .values(name=room.name, manager_id=room.manager_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def delete_room(db: AsyncSession, room_id: str):
@@ -305,8 +267,4 @@ async def delete_room(db: AsyncSession, room_id: str):
     await db.execute(
         delete(models_booking.Room).where(models_booking.Room.id == room_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()

--- a/app/modules/booking/cruds_booking.py
+++ b/app/modules/booking/cruds_booking.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/booking/endpoints_booking.py
+++ b/app/modules/booking/endpoints_booking.py
@@ -72,16 +72,13 @@ async def create_manager(
             detail="Invalid id, group_id must be a valid group id",
         )
 
-    try:
-        manager_db = models_booking.Manager(
-            id=str(uuid.uuid4()),
-            name=manager.name,
-            group_id=manager.group_id,
-        )
+    manager_db = models_booking.Manager(
+        id=str(uuid.uuid4()),
+        name=manager.name,
+        group_id=manager.group_id,
+    )
 
-        return await cruds_booking.create_manager(manager=manager_db, db=db)
-    except ValueError as error:
-        raise HTTPException(status_code=422, detail=str(error))
+    return await cruds_booking.create_manager(manager=manager_db, db=db)
 
 
 @module.router.patch(
@@ -319,14 +316,11 @@ async def edit_booking(
             detail="You are not allowed to edit this booking",
         )
 
-    try:
-        await cruds_booking.edit_booking(
-            booking_id=booking_id,
-            booking=booking_edit,
-            db=db,
-        )
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
+    await cruds_booking.edit_booking(
+        booking_id=booking_id,
+        booking=booking_edit,
+        db=db,
+    )
 
 
 @module.router.patch(
@@ -427,14 +421,11 @@ async def create_room(
     **This endpoint is only usable by admins**
     """
 
-    try:
-        room_db = models_booking.Room(
-            id=str(uuid.uuid4()),
-            **room.model_dump(),
-        )
-        return await cruds_booking.create_room(db=db, room=room_db)
-    except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error))
+    room_db = models_booking.Room(
+        id=str(uuid.uuid4()),
+        **room.model_dump(),
+    )
+    return await cruds_booking.create_room(db=db, room=room_db)
 
 
 @module.router.patch(

--- a/app/modules/calendar/cruds_calendar.py
+++ b/app/modules/calendar/cruds_calendar.py
@@ -64,13 +64,8 @@ async def add_event(
     """Add an event to the database."""
 
     db.add(event)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return event
+    await db.flush()
+    return event
 
 
 async def edit_event(
@@ -83,11 +78,7 @@ async def edit_event(
         .where(models_calendar.Event.id == event_id)
         .values(**event.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def delete_event(db: AsyncSession, event_id: str) -> None:
@@ -95,16 +86,8 @@ async def delete_event(db: AsyncSession, event_id: str) -> None:
     await db.execute(
         delete(models_calendar.Event).where(models_calendar.Event.id == event_id),
     )
-    try:
-        await db.commit()
-        try:
-            await create_icalendar_file(db)
-        except Exception as error:
-            await db.rollback()
-            raise ValueError(error)
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
+    await create_icalendar_file(db)
 
 
 async def confirm_event(db: AsyncSession, decision: Decision, event_id: str):
@@ -113,17 +96,9 @@ async def confirm_event(db: AsyncSession, decision: Decision, event_id: str):
         .where(models_calendar.Event.id == event_id)
         .values(decision=decision),
     )
-    try:
-        await db.commit()
-        if decision == Decision.approved:
-            try:
-                await create_icalendar_file(db)
-            except Exception as error:
-                await db.rollback()
-                raise ValueError(error)
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
+    if decision == Decision.approved:
+        await create_icalendar_file(db)
 
 
 async def create_icalendar_file(db: AsyncSession) -> None:

--- a/app/modules/calendar/cruds_calendar.py
+++ b/app/modules/calendar/cruds_calendar.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 import aiofiles
 from icalendar import Calendar, Event, vRecur
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/calendar/endpoints_calendar.py
+++ b/app/modules/calendar/endpoints_calendar.py
@@ -132,10 +132,8 @@ async def add_event(
         applicant_id=user.id,
         **event.model_dump(),
     )
-    try:
-        return await cruds_calendar.add_event(event=db_event, db=db)
-    except ValueError as error:
-        raise HTTPException(status_code=422, detail=str(error))
+
+    return await cruds_calendar.add_event(event=db_event, db=db)
 
 
 @module.router.patch(
@@ -164,10 +162,7 @@ async def edit_bookings_id(
             detail="You are not allowed to edit this event",
         )
 
-    try:
-        await cruds_calendar.edit_event(event_id=event_id, event=event_edit, db=db)
-    except ValueError as error:
-        raise HTTPException(status_code=422, detail=str(error))
+    await cruds_calendar.edit_event(event_id=event_id, event=event_edit, db=db)
 
 
 @module.router.patch(

--- a/app/modules/campaign/cruds_campaign.py
+++ b/app/modules/campaign/cruds_campaign.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 
 from fastapi import HTTPException
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/campaign/cruds_campaign.py
+++ b/app/modules/campaign/cruds_campaign.py
@@ -32,11 +32,7 @@ async def get_status(
         # Since this is the only place a row can be added to the status table, there should never be more than one row in the table
         status_model = models_campaign.Status(status=StatusType.waiting, id="id")
         db.add(status_model)
-        try:
-            await db.commit()
-        except IntegrityError:
-            await db.rollback()
-            raise
+        await db.flush()
         return StatusType.waiting
 
     # The status is contained in the only result returned by the database
@@ -53,11 +49,7 @@ async def add_voter(
     db: AsyncSession,
 ) -> None:
     db.add(voter)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def delete_voter_by_group_id(
@@ -69,14 +61,14 @@ async def delete_voter_by_group_id(
             models_campaign.VoterGroups.group_id == group_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_voters(
     db: AsyncSession,
 ) -> None:
     await db.execute(delete(models_campaign.VoterGroups))
-    await db.commit()
+    await db.flush()
 
 
 async def set_status(
@@ -84,7 +76,7 @@ async def set_status(
     new_status: StatusType,
 ):
     await db.execute(update(models_campaign.Status).values(status=new_status))
-    await db.commit()
+    await db.flush()
 
 
 async def get_vote_count(db: AsyncSession, section_id: str):
@@ -112,11 +104,7 @@ async def add_blank_option(db: AsyncSession):
                 members=[],
             ),
         )
-    try:
-        await db.commit()
-    except IntegrityError as err:
-        await db.rollback()
-        raise ValueError(err)
+    await db.flush()
 
 
 async def get_sections(db: AsyncSession) -> Sequence[models_campaign.Sections]:
@@ -143,11 +131,7 @@ async def get_section_by_id(db: AsyncSession, section_id: str):
 async def add_section(db: AsyncSession, section: models_campaign.Sections) -> None:
     """Add a section of AEECL."""
     db.add(section)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def delete_section(db: AsyncSession, section_id: str) -> None:
@@ -172,7 +156,7 @@ async def delete_section(db: AsyncSession, section_id: str) -> None:
                     models_campaign.Sections.id == section_id,
                 ),
             )
-            await db.commit()
+            await db.flush()
         else:
             raise HTTPException(status_code=400, detail="This section still has lists")
     else:
@@ -185,7 +169,7 @@ async def delete_lists_from_section(db: AsyncSession, section_id: str) -> None:
             models_campaign.Lists.section_id == section_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_lists(db: AsyncSession) -> Sequence[models_campaign.Lists]:
@@ -227,11 +211,7 @@ async def add_list(
 ) -> None:
     """Add a list to a section then add the members to the list."""
     db.add(campaign_list)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def remove_members_from_list(
@@ -246,7 +226,7 @@ async def remove_members_from_list(
             models_campaign.ListMemberships.list_id == list_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_list(db: AsyncSession, list_id: str) -> None:
@@ -255,7 +235,7 @@ async def delete_list(db: AsyncSession, list_id: str) -> None:
     await db.execute(
         delete(models_campaign.Lists).where(models_campaign.Lists.id == list_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_list_by_type(list_type: ListType, db: AsyncSession) -> None:
@@ -269,7 +249,7 @@ async def delete_list_by_type(list_type: ListType, db: AsyncSession) -> None:
     await db.execute(
         delete(models_campaign.Lists).where(models_campaign.Lists.type == list_type),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_list(
@@ -306,21 +286,13 @@ async def update_list(
             ),
         )
 
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise ValueError()
+    await db.flush()
 
 
 async def add_vote(db: AsyncSession, vote: models_campaign.Votes) -> None:
     """Add a vote."""
     db.add(vote)
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def has_user_voted_for_section(
@@ -343,11 +315,7 @@ async def mark_has_voted(db: AsyncSession, user_id: str, section_id: str) -> Non
     """Mark user has having vote for the given section."""
     has_voted = models_campaign.HasVoted(user_id=user_id, section_id=section_id)
     db.add(has_voted)
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
+    await db.flush()
 
 
 async def get_has_voted(
@@ -372,7 +340,7 @@ async def delete_votes(db: AsyncSession) -> None:
     """Delete all votes in the db."""
     await db.execute(delete(models_campaign.Votes))
     await db.execute(delete(models_campaign.HasVoted))
-    await db.commit()
+    await db.flush()
 
 
 async def reset_campaign(db: AsyncSession) -> None:
@@ -380,5 +348,5 @@ async def reset_campaign(db: AsyncSession) -> None:
     This will delete all the votes and blank list lists."""
     await db.execute(delete(models_campaign.Votes))
     await db.execute(delete(models_campaign.HasVoted))
-    await db.commit()
+    await db.flush()
     await delete_list_by_type(ListType.blank, db)

--- a/app/modules/cdr/utils_cdr.py
+++ b/app/modules/cdr/utils_cdr.py
@@ -56,13 +56,10 @@ async def validate_payment(
         action=str(checkout_payment.__dict__),
         timestamp=datetime.now(UTC),
     )
-    try:
-        cruds_cdr.create_payment(db=db, payment=db_payment)
-        cruds_cdr.create_action(db=db, action=db_action)
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+
+    cruds_cdr.create_payment(db=db, payment=db_payment)
+    cruds_cdr.create_action(db=db, action=db_action)
+    await db.flush()
 
 
 async def is_user_in_a_seller_group(

--- a/app/modules/cinema/cruds_cinema.py
+++ b/app/modules/cinema/cruds_cinema.py
@@ -45,10 +45,7 @@ async def create_session(
 ) -> models_cinema.Session:
     db_session = models_cinema.Session(**session.model_dump())
     db.add(db_session)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
+    await db.flush()
     return db_session
 
 
@@ -62,11 +59,11 @@ async def update_session(
         .where(models_cinema.Session.id == session_id)
         .values(**session_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_session(session_id: str, db: AsyncSession):
     await db.execute(
         delete(models_cinema.Session).where(models_cinema.Session.id == session_id),
     )
-    await db.commit()
+    await db.flush()

--- a/app/modules/cinema/cruds_cinema.py
+++ b/app/modules/cinema/cruds_cinema.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from datetime import datetime
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.cinema import models_cinema, schemas_cinema

--- a/app/modules/flappybird/cruds_flappybird.py
+++ b/app/modules/flappybird/cruds_flappybird.py
@@ -53,13 +53,8 @@ async def create_flappybird_score(
 ) -> models_flappybird.FlappyBirdScore:
     """Add a FlappyBirdScore in database"""
     db.add(flappybird_score)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return flappybird_score
+    await db.flush()
+    return flappybird_score
 
 
 async def create_flappybird_best_score(
@@ -68,13 +63,8 @@ async def create_flappybird_best_score(
 ) -> models_flappybird.FlappyBirdBestScore:
     """Add a FlappyBirdBestScore in database"""
     db.add(flappybird_best_score)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return flappybird_best_score
+    await db.flush()
+    return flappybird_best_score
 
 
 async def delete_flappybird_best_score(

--- a/app/modules/flappybird/cruds_flappybird.py
+++ b/app/modules/flappybird/cruds_flappybird.py
@@ -1,5 +1,4 @@
 from sqlalchemy import delete, func, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/loan/cruds_loan.py
+++ b/app/modules/loan/cruds_loan.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from datetime import datetime
 
 from sqlalchemy import delete, func, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/loan/cruds_loan.py
+++ b/app/modules/loan/cruds_loan.py
@@ -28,13 +28,8 @@ async def create_loaner(
     """Create a new loaner in database and return it"""
 
     db.add(loaner)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return loaner
+    await db.flush()
+    return loaner
 
 
 async def update_loaner(
@@ -47,7 +42,7 @@ async def update_loaner(
         .where(models_loan.Loaner.id == loaner_id)
         .values(**loaner_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_loaner_by_id(
@@ -71,7 +66,7 @@ async def delete_loaner_by_id(
     await db.execute(
         delete(models_loan.Loaner).where(models_loan.Loaner.id == loaner_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_item(
@@ -79,13 +74,8 @@ async def create_item(
     db: AsyncSession,
 ) -> models_loan.Item:
     db.add(item)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return item
+    await db.flush()
+    return item
 
 
 async def get_loaner_item_by_id(
@@ -126,7 +116,7 @@ async def update_loaner_item(
         .where(models_loan.Item.id == item_id)
         .values(**item_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_loaner_items_by_loaner_id(
@@ -136,7 +126,7 @@ async def delete_loaner_items_by_loaner_id(
     await db.execute(
         delete(models_loan.Item).where(models_loan.Item.loaner_id == loaner_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_loaner_item_by_id(
@@ -144,7 +134,7 @@ async def delete_loaner_item_by_id(
     db: AsyncSession,
 ):
     await db.execute(delete(models_loan.Item).where(models_loan.Item.id == item_id))
-    await db.commit()
+    await db.flush()
 
 
 async def get_loans_by_borrower(
@@ -170,13 +160,8 @@ async def create_loan(
     loan: models_loan.Loan,
 ) -> models_loan.Loan:
     db.add(loan)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return loan
+    await db.flush()
+    return loan
 
 
 async def update_loan(
@@ -189,7 +174,7 @@ async def update_loan(
         .where(models_loan.Loan.id == loan_id)
         .values(**loan_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_loan_returned_status(
@@ -208,7 +193,7 @@ async def update_loan_returned_status(
             },
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_loan_by_id(
@@ -228,7 +213,7 @@ async def delete_loan_by_id(
     db: AsyncSession,
 ):
     await db.execute(delete(models_loan.Loan).where(models_loan.Loan.id == loan_id))
-    await db.commit()
+    await db.flush()
 
 
 async def create_loan_content(
@@ -240,11 +225,7 @@ async def create_loan_content(
     """
 
     db.add(loan_content)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def get_loan_content_by_loan_id_item_id(
@@ -296,7 +277,7 @@ async def delete_loan_content_by_loan_id(
             models_loan.LoanContent.loan_id == loan_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_loan_content_by_item_id(
@@ -308,4 +289,4 @@ async def delete_loan_content_by_item_id(
             models_loan.LoanContent.item_id == item_id,
         ),
     )
-    await db.commit()
+    await db.flush()

--- a/app/modules/ph/cruds_ph.py
+++ b/app/modules/ph/cruds_ph.py
@@ -3,7 +3,6 @@ from collections.abc import Sequence
 from datetime import date
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.ph import models_ph, schemas_ph

--- a/app/modules/ph/cruds_ph.py
+++ b/app/modules/ph/cruds_ph.py
@@ -39,13 +39,8 @@ async def create_paper(
     """Create a new paper in database and return it"""
 
     db.add(paper)
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError(error)
-    else:
-        return paper
+    await db.flush()
+    return paper
 
 
 async def update_paper(
@@ -58,7 +53,7 @@ async def update_paper(
         .where(models_ph.Paper.id == paper_id)
         .values(**paper_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_paper(
@@ -68,4 +63,4 @@ async def delete_paper(
     await db.execute(
         delete(models_ph.Paper).where(models_ph.Paper.id == paper_id),
     )
-    await db.commit()
+    await db.flush()

--- a/app/modules/phonebook/cruds_phonebook.py
+++ b/app/modules/phonebook/cruds_phonebook.py
@@ -80,10 +80,7 @@ async def create_association(
     """Create a new Association in database and return it"""
 
     db.add(association)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
+    await db.flush()
     return association
 
 
@@ -99,11 +96,7 @@ async def update_association(
         .where(models_phonebook.Association.id == association_id)
         .values(**association_edit.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def update_association_groups(
@@ -126,11 +119,7 @@ async def update_association_groups(
                 group_id=group_id,
             ),
         )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def deactivate_association(association_id: str, db: AsyncSession):
@@ -141,11 +130,7 @@ async def deactivate_association(association_id: str, db: AsyncSession):
         .where(models_phonebook.Association.id == association_id)
         .values(deactivated=True),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def delete_association(association_id: str, db: AsyncSession):
@@ -167,11 +152,7 @@ async def delete_association(association_id: str, db: AsyncSession):
             models_phonebook.Association.id == association_id,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def get_association_by_id(
@@ -209,11 +190,7 @@ async def get_associated_groups_by_association_id(
 async def create_membership(membership: models_phonebook.Membership, db: AsyncSession):
     """Create a Membership in database"""
     db.add(membership)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def update_membership(
@@ -228,11 +205,7 @@ async def update_membership(
         .where(models_phonebook.Membership.id == membership_id)
         .values(**membership_edit.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def update_order_of_memberships(
@@ -279,11 +252,7 @@ async def update_order_of_memberships(
             )
             .values(member_order=models_phonebook.Membership.member_order - 1),
         )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def delete_membership(membership_id: str, db: AsyncSession):
@@ -294,11 +263,7 @@ async def delete_membership(membership_id: str, db: AsyncSession):
             models_phonebook.Membership.id == membership_id,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def get_memberships_by_user_id(

--- a/app/modules/phonebook/cruds_phonebook.py
+++ b/app/modules/phonebook/cruds_phonebook.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.users import models_users

--- a/app/modules/raffle/cruds_raffle.py
+++ b/app/modules/raffle/cruds_raffle.py
@@ -32,13 +32,8 @@ async def create_raffle(
     """Create a new raffle in database and return it"""
 
     db.add(raffle)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return raffle
+    await db.flush()
+    return raffle
 
 
 async def get_raffles_by_groupid(
@@ -71,7 +66,7 @@ async def edit_raffle(
         .where(models_raffle.Raffle.id == raffle_id)
         .values(**raffle_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_raffle(
@@ -83,7 +78,7 @@ async def delete_raffle(
     await db.execute(
         delete(models_raffle.Raffle).where(models_raffle.Raffle.id == raffle_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_prizes(db: AsyncSession) -> Sequence[models_raffle.Prize]:
@@ -102,13 +97,8 @@ async def create_prize(
     """Create a new prize in databasend return it"""
 
     db.add(prize)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return prize
+    await db.flush()
+    return prize
 
 
 async def get_prizes_by_raffleid(
@@ -143,7 +133,7 @@ async def edit_prize(
         .where(models_raffle.Prize.id == prize_id)
         .values(**prize_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_prize(
@@ -155,7 +145,7 @@ async def delete_prize(
     await db.execute(
         delete(models_raffle.Prize).where(models_raffle.Prize.id == prize_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_prizes_by_raffleid(db: AsyncSession, raffle_id: str):
@@ -166,7 +156,7 @@ async def delete_prizes_by_raffleid(db: AsyncSession, raffle_id: str):
             models_raffle.Prize.id.in_([prize.id for prize in prizes_to_delete]),
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_packtickets(db: AsyncSession) -> Sequence[models_raffle.PackTicket]:
@@ -187,13 +177,8 @@ async def create_packticket(
     """Create a new Packticket in databasend return it"""
 
     db.add(packticket)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return packticket
+    await db.flush()
+    return packticket
 
 
 async def get_packtickets_by_raffleid(
@@ -230,7 +215,7 @@ async def edit_packticket(
         .where(models_raffle.PackTicket.id == packticket_id)
         .values(**packticket_update.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_packticket(
@@ -244,7 +229,7 @@ async def delete_packticket(
             models_raffle.PackTicket.id == packticket_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_packtickets_by_raffleid(db: AsyncSession, raffle_id: str):
@@ -258,7 +243,7 @@ async def delete_packtickets_by_raffleid(db: AsyncSession, raffle_id: str):
             models_raffle.PackTicket.id.in_([p.id for p in packtickets_to_delete]),
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_tickets(db: AsyncSession) -> Sequence[models_raffle.Ticket]:
@@ -274,13 +259,8 @@ async def create_ticket(
 ) -> Sequence[models_raffle.Ticket]:
     """Create a new ticket in databasend return it"""
     db.add_all(tickets)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return tickets
+    await db.flush()
+    return tickets
 
 
 async def get_tickets_by_raffleid(
@@ -342,7 +322,7 @@ async def delete_ticket(
     await db.execute(
         delete(models_raffle.Ticket).where(models_raffle.Ticket.id == ticket_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_tickets_by_raffleid(db: AsyncSession, raffle_id: str):
@@ -353,7 +333,7 @@ async def delete_tickets_by_raffleid(db: AsyncSession, raffle_id: str):
             models_raffle.Ticket.id.in_([t.id for t in tickets_to_delete]),
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_users_cash(db: AsyncSession) -> Sequence[models_raffle.Cash]:
@@ -377,13 +357,8 @@ async def create_cash_of_user(
     cash: models_raffle.Cash,
 ) -> models_raffle.Cash:
     db.add(cash)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return cash
+    await db.flush()
+    return cash
 
 
 async def edit_cash(db: AsyncSession, user_id: str, amount: float):
@@ -392,11 +367,7 @@ async def edit_cash(db: AsyncSession, user_id: str, amount: float):
         .where(models_raffle.Cash.user_id == user_id)
         .values(user_id=user_id, balance=amount),
     )
-    try:
-        await db.commit()
-    except IntegrityError as err:
-        await db.rollback()
-        raise ValueError(err)
+    await db.flush()
 
 
 async def draw_winner_by_prize_raffle(
@@ -422,22 +393,14 @@ async def draw_winner_by_prize_raffle(
         .where(models_raffle.Ticket.id.in_([w.id for w in winners]))
         .values(winning_prize=prize_id),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError("Error during edition of the winning tickets") from error  # noqa: TRY003
+    await db.flush()
 
     await db.execute(
         update(models_raffle.Prize)
         .where(models_raffle.Prize.id == prize_id)
         .values(quantity=prize.quantity - len(winners)),
     )
-    try:
-        await db.commit()
-    except IntegrityError as error:
-        await db.rollback()
-        raise ValueError("Error during edition of the prize") from error  # noqa: TRY003
+    await db.flush()
 
     return winners
 
@@ -455,4 +418,4 @@ async def change_raffle_status(
         .where(models_raffle.Raffle.id == raffle_id)
         .values(status=status),
     )
-    await db.commit()
+    await db.flush()

--- a/app/modules/raffle/cruds_raffle.py
+++ b/app/modules/raffle/cruds_raffle.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 
 from fastapi import HTTPException
 from sqlalchemy import delete, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 

--- a/app/modules/raffle/endpoints_raffle.py
+++ b/app/modules/raffle/endpoints_raffle.py
@@ -930,10 +930,6 @@ async def edit_cash_by_id(
             amount=cash.balance + balance.balance,
             db=db,
         )
-    except ValueError:
-        hyperion_error_logger.exception("Error in tombola edit_cash_by_id")
-        raise HTTPException(status_code=400, detail="Error while editing cash.")
-
     finally:
         locker_set(redis_client=redis_client, key=redis_key, lock=False)
 
@@ -969,13 +965,10 @@ async def draw_winner(
             detail="Raffle must be locked to draw a prize",
         )
 
-    try:
-        winning_tickets = await cruds_raffle.draw_winner_by_prize_raffle(
-            prize_id=prize_id,
-            db=db,
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    winning_tickets = await cruds_raffle.draw_winner_by_prize_raffle(
+        prize_id=prize_id,
+        db=db,
+    )
 
     for ticket in winning_tickets:
         ticket.prize = prize

--- a/app/modules/raid/cruds_raid.py
+++ b/app/modules/raid/cruds_raid.py
@@ -15,13 +15,8 @@ async def create_participant(
     db: AsyncSession,
 ) -> models_raid.Participant:
     db.add(participant)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return participant
+    await db.flush()
+    return participant
 
 
 async def get_all_participants(
@@ -51,7 +46,7 @@ async def update_participant(
     if is_minor:
         query = query.values(is_minor=is_minor)
     await db.execute(query)
-    await db.commit()
+    await db.flush()
 
 
 async def update_participant_minority(
@@ -64,7 +59,7 @@ async def update_participant_minority(
         .where(models_raid.Participant.id == participant_id)
         .values(is_minor=is_minor),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def is_user_a_participant(
@@ -144,11 +139,7 @@ async def create_team(
     db: AsyncSession,
 ) -> None:
     db.add(team)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    await db.flush()
 
 
 async def update_team(
@@ -161,7 +152,7 @@ async def update_team(
         .where(models_raid.Team.id == team_id)
         .values(**team.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_team_captain_id(
@@ -174,7 +165,7 @@ async def update_team_captain_id(
         .where(models_raid.Team.id == team_id)
         .values(captain_id=captain_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_team_second_id(
@@ -187,7 +178,7 @@ async def update_team_second_id(
         .where(models_raid.Team.id == team_id)
         .values(second_id=second_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_participant(
@@ -199,7 +190,7 @@ async def delete_participant(
             models_raid.Participant.id == participant_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_team_invite_tokens(
@@ -211,7 +202,7 @@ async def delete_team_invite_tokens(
             models_raid.InviteToken.team_id == team_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def delete_all_invite_tokens(
@@ -226,14 +217,14 @@ async def delete_team(
     db: AsyncSession,
 ) -> None:
     await db.execute(delete(models_raid.Team).where(models_raid.Team.id == team_id))
-    await db.commit()
+    await db.flush()
 
 
 async def delete_all_teams(
     db: AsyncSession,
 ) -> None:
     await db.execute(delete(models_raid.Team))
-    await db.commit()
+    await db.flush()
 
 
 async def add_security_file(
@@ -241,14 +232,8 @@ async def add_security_file(
     db: AsyncSession,
 ) -> models_raid.SecurityFile:
     db.add(security_file)
-    try:
-        await db.commit()
-
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return security_file
+    await db.flush()
+    return security_file
 
 
 async def delete_security_file(
@@ -260,7 +245,7 @@ async def delete_security_file(
             models_raid.SecurityFile.id == security_file_id,
         ),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_security_file(
@@ -273,7 +258,7 @@ async def update_security_file(
         .where(models_raid.SecurityFile.id == security_file_id)
         .values(**security_file.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_security_file_id(
@@ -286,7 +271,7 @@ async def update_security_file_id(
         .where(models_raid.SecurityFile.id == security_file_id)
         .values(file_id=file_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def assign_security_file(
@@ -299,7 +284,7 @@ async def assign_security_file(
         .where(models_raid.Participant.id == participant_id)
         .values(security_file_id=security_file_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def create_document(
@@ -307,14 +292,8 @@ async def create_document(
     db: AsyncSession,
 ) -> models_raid.Document:
     db.add(document)
-    try:
-        await db.commit()
-
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return document
+    await db.flush()
+    return document
 
 
 async def assign_document(
@@ -328,7 +307,7 @@ async def assign_document(
         .where(models_raid.Participant.id == participant_id)
         .values({document_key: document_id}),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def update_document_validation(
@@ -341,7 +320,7 @@ async def update_document_validation(
         .where(models_raid.Document.id == document_id)
         .values(validation=validation),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_document_by_id(
@@ -376,13 +355,8 @@ async def upload_document(
     db: AsyncSession,
 ) -> models_raid.Document:
     db.add(document)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return document
+    await db.flush()
+    return document
 
 
 async def update_document(
@@ -395,7 +369,7 @@ async def update_document(
         .where(models_raid.Document.id == document_id)
         .values(**document.model_dump(exclude_none=True)),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def mark_document_as_newly_updated(
@@ -408,7 +382,7 @@ async def mark_document_as_newly_updated(
         .values(uploaded_at=datetime.now(tz=UTC).date(), validation="pending"),
     )
 
-    await db.commit()
+    await db.flush()
 
 
 async def confirm_payment(
@@ -420,7 +394,7 @@ async def confirm_payment(
         .where(models_raid.Participant.id == participant_id)
         .values(payment=True),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def confirm_t_shirt_payment(
@@ -432,7 +406,7 @@ async def confirm_t_shirt_payment(
         .where(models_raid.Participant.id == participant_id)
         .values(t_shirt_payment=True),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def validate_attestation_on_honour(
@@ -444,7 +418,7 @@ async def validate_attestation_on_honour(
         .where(models_raid.Participant.id == participant_id)
         .values(attestation_on_honour=True),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_participant_by_id(
@@ -485,13 +459,9 @@ async def create_invite_token(
     db: AsyncSession,
 ) -> models_raid.InviteToken:
     db.add(invite)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return invite
+    await db.flush()
+
+    return invite
 
 
 async def get_invite_token_by_team_id(
@@ -523,7 +493,7 @@ async def delete_invite_token(
     await db.execute(
         delete(models_raid.InviteToken).where(models_raid.InviteToken.id == token_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def are_user_in_the_same_team(
@@ -565,7 +535,7 @@ async def update_team_file_id(
         .where(models_raid.Team.id == team_id)
         .values(file_id=file_id),
     )
-    await db.commit()
+    await db.flush()
 
 
 async def get_number_of_team_by_difficulty(
@@ -583,13 +553,8 @@ async def create_participant_checkout(
     db: AsyncSession,
 ) -> models_raid.ParticipantCheckout:
     db.add(checkout)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
-    else:
-        return checkout
+    await db.flush()
+    return checkout
 
 
 async def get_participant_checkout_by_checkout_id(

--- a/app/modules/raid/cruds_raid.py
+++ b/app/modules/raid/cruds_raid.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, func, or_, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/app/modules/recommendation/cruds_recommendation.py
+++ b/app/modules/recommendation/cruds_recommendation.py
@@ -19,7 +19,7 @@ async def create_recommendation(
     db: AsyncSession,
 ) -> models_recommendation.Recommendation:
     db.add(recommendation)
-    await db.commit()
+    await db.flush()
     return recommendation
 
 
@@ -37,7 +37,7 @@ async def update_recommendation(
         .values(**recommendation.model_dump(exclude_none=True)),
     )
     if result.rowcount == 1:
-        await db.commit()
+        await db.flush()
     else:
         await db.rollback()
         raise ValueError
@@ -53,7 +53,7 @@ async def delete_recommendation(
         ),
     )
     if result.rowcount == 1:
-        await db.commit()
+        await db.flush()
     else:
         await db.rollback()
         raise ValueError

--- a/app/modules/seed_library/cruds_seed_library.py
+++ b/app/modules/seed_library/cruds_seed_library.py
@@ -38,7 +38,7 @@ async def create_species(
         time_maturation=species.time_maturation,
     )
     db.add(species_db)
-    db.flush()
+    await db.flush()
     return species_db
 
 
@@ -54,7 +54,7 @@ async def update_species(
         .where(models_seed_library.Species.id == species_id)
         .values(**species_edit.model_dump(exclude_none=True)),
     )
-    db.flush()
+    await db.flush()
 
 
 async def delete_species(species_id: uuid.UUID, db: AsyncSession):
@@ -70,7 +70,7 @@ async def delete_species(species_id: uuid.UUID, db: AsyncSession):
             models_seed_library.Species.id == species_id,
         ),
     )
-    db.flush()
+    await db.flush()
 
 
 async def get_all_species(
@@ -158,7 +158,7 @@ async def create_plant(
         borrowing_date=plant.borrowing_date,
     )
     db.add(plant_db)
-    db.flush()
+    await db.flush()
     return plant_db
 
 
@@ -174,7 +174,7 @@ async def update_plant(
         .where(models_seed_library.Plant.id == plant_id)
         .values(**plant_edit.model_dump(exclude_none=True)),
     )
-    db.flush()
+    await db.flush()
 
 
 async def delete_plant(plant_id: uuid.UUID, db: AsyncSession):
@@ -185,7 +185,7 @@ async def delete_plant(plant_id: uuid.UUID, db: AsyncSession):
             models_seed_library.Plant.id == plant_id,
         ),
     )
-    db.flush()
+    await db.flush()
 
 
 async def get_plants_by_user_id(
@@ -318,7 +318,7 @@ async def borrow_plant(
             state=PlantState.retrieved,
         ),
     )
-    db.flush()
+    await db.flush()
 
 
 async def count_plants_created_today(

--- a/app/modules/seed_library/cruds_seed_library.py
+++ b/app/modules/seed_library/cruds_seed_library.py
@@ -38,11 +38,7 @@ async def create_species(
         time_maturation=species.time_maturation,
     )
     db.add(species_db)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
     return species_db
 
 
@@ -58,11 +54,7 @@ async def update_species(
         .where(models_seed_library.Species.id == species_id)
         .values(**species_edit.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
 
 
 async def delete_species(species_id: uuid.UUID, db: AsyncSession):
@@ -78,11 +70,7 @@ async def delete_species(species_id: uuid.UUID, db: AsyncSession):
             models_seed_library.Species.id == species_id,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
 
 
 async def get_all_species(
@@ -170,11 +158,7 @@ async def create_plant(
         borrowing_date=plant.borrowing_date,
     )
     db.add(plant_db)
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
     return plant_db
 
 
@@ -190,11 +174,7 @@ async def update_plant(
         .where(models_seed_library.Plant.id == plant_id)
         .values(**plant_edit.model_dump(exclude_none=True)),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
 
 
 async def delete_plant(plant_id: uuid.UUID, db: AsyncSession):
@@ -205,11 +185,7 @@ async def delete_plant(plant_id: uuid.UUID, db: AsyncSession):
             models_seed_library.Plant.id == plant_id,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
 
 
 async def get_plants_by_user_id(
@@ -342,11 +318,7 @@ async def borrow_plant(
             state=PlantState.retrieved,
         ),
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise
+    db.flush()
 
 
 async def count_plants_created_today(

--- a/app/modules/seed_library/cruds_seed_library.py
+++ b/app/modules/seed_library/cruds_seed_library.py
@@ -3,7 +3,6 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, func, select, update
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.seed_library import (

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -182,13 +182,16 @@ async def create_user_with_groups(
                     ),
                 )
             await db.commit()
-            user_db = await cruds_users.get_user_by_id(db, user_id)
         except Exception as error:
             await db.rollback()
             raise FailedToAddObjectToDB from error
         finally:
             await db.close()
-    return user_db  # type: ignore[return-value] # (user_db can't be None)
+
+    async with TestingSessionLocal() as db:
+        user_db = await cruds_users.get_user_by_id(db, user_id)
+
+        return user_db  # type: ignore[return-value] # (user_db can't be None)
 
 
 def create_api_access_token(

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 import redis
 from fastapi import Depends, HTTPException
 from sqlalchemy import NullPool
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.auth import schemas_auth
@@ -189,9 +188,7 @@ async def create_user_with_groups(
             await db.close()
 
     async with TestingSessionLocal() as db:
-        user_db = await cruds_users.get_user_by_id(db, user_id)
-
-        return user_db  # type: ignore[return-value] # (user_db can't be None)
+        return await cruds_users.get_user_by_id(db, user_id)
 
 
 def create_api_access_token(

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -188,7 +188,9 @@ async def create_user_with_groups(
             await db.close()
 
     async with TestingSessionLocal() as db:
-        return await cruds_users.get_user_by_id(db, user_id)
+        user_db = await cruds_users.get_user_by_id(db, user_id)
+        assert user_db is not None
+        return user_db
 
 
 def create_api_access_token(


### PR DESCRIPTION
Open a transaction per request, to ensure that everything will be either committed or rollback.

## Migration strategy

Existing `db.commit()` were replaced by `db.flush()` even when it may not have been necessary to prevent creating unexpected regressions.


## Advanced usage

The database transaction is automatically commited at the end.

 - If an HTTPException is raised during the request, we consider that the error was expected and managed by the endpoint. We commit the session.
 - If an other exception is raised, we rollback the session to avoid.

> Cruds and endpoints should never call `db.commit()` or `db.rollback()` directly.
>After adding an object to the session, calling `await db.flush()` will integrate the changes in the transaction without committing them.

> If an endpoint needs to add objects to the sessions that should be committed even in case of an unexpected error, it should start a SAVEPOINT after adding the object.
> ```python
> # Add here the object that should always be committed, even in case of an unexpected error
> await db.add(object)
> await db.flush()
> # Start a SAVEPOINT. If the code in the following context manager raises an exception, the changes will be rolled back to this point.
> async with db.begin_nested():
>     # Add objects that may be rolled back in case of an error here
> ```
---


Supersede #498