### PR TITLE
Catch bad "To:" in mails

### DIFF
--- a/app/utils/mail/mailworker.py
+++ b/app/utils/mail/mailworker.py
@@ -43,6 +43,6 @@ def send_email(
         try:
             server.send_message(msg, settings.SMTP_EMAIL, recipient)
         except smtplib.SMTPRecipientsRefused:
-            hyperion_error_logger.error(  # noqa: TRY400
+            hyperion_error_logger.warning(
                 f'Bad email adress: "{", ".join(recipient)}" for mail with subject "{subject}".',
             )


### PR DESCRIPTION
I don't like receiving every other day a monstruosity like:
> uvicorn.error - ERROR - Exception in ASGI application + Exception Group Traceback (most recent call last): | File "/usr/local/lib/python3.11/site-packages/starlette/_[utils.py](http://utils.py/)", line 76, in collapse_excgroups | yield | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 186, in __call__ | async with anyio.create_task_group() as task_group: | File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_[asyncio.py](http://asyncio.py/)", line 772, in __aexit__ | raise BaseExceptionGroup( | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception) +-+---------------- 1 ---------------- | Traceback (most recent call last): | File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_[impl.py](http://impl.py/)", line 401, in run_asgi | result = await app( # type: ignore[func-returns-value] | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_[headers.py](http://headers.py/)", line 70, in __call__ | return await [self.app](http://self.app/)(scope, receive, send) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/site-packages/fastapi/[applications.py](http://applications.py/)", line 1054, in __call__ | await super().__call__(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/[applications.py](http://applications.py/)", line 113, in __call__ | await self.middleware_stack(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[errors.py](http://errors.py/)", line 187, in __call__ | raise exc | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[errors.py](http://errors.py/)", line 165, in __call__ | await [self.app](http://self.app/)(scope, receive, _send) | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 185, in __call__ | with collapse_excgroups(): | File "/usr/local/lib/python3.11/[contextlib.py](http://contextlib.py/)", line 158, in __exit__ | self.gen.throw(typ, value, traceback) | File "/usr/local/lib/python3.11/site-packages/starlette/_[utils.py](http://utils.py/)", line 82, in collapse_excgroups | raise exc | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 187, in __call__ | response = await self.dispatch_func(request, call_next) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/hyperion/app/[app.py](http://app.py/)", line 500, in logging_middleware | response = await call_next(request) | ^^^^^^^^^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 163, in call_next | raise app_exc | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 149, in coro | await [self.app](http://self.app/)(scope, receive_or_disconnect, send_no_error) | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[cors.py](http://cors.py/)", line 85, in __call__ | await [self.app](http://self.app/)(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[exceptions.py](http://exceptions.py/)", line 62, in __call__ | await wrap_app_handling_exceptions([self.app](http://self.app/), conn)(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 53, in wrapped_app | raise exc | File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 42, in wrapped_app | await app(scope, receive, sender) | File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 715, in __call__ | await self.middleware_stack(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 735, in app | await route.handle(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 288, in handle | await [self.app](http://self.app/)(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 76, in app | await wrap_app_handling_exceptions(app, request)(scope, receive, send) | File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 53, in wrapped_app | raise exc | File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 42, in wrapped_app | await app(scope, receive, sender) | File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 73, in app | response = await f(request) | ^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/site-packages/fastapi/[routing.py](http://routing.py/)", line 301, in app | raw_response = await run_endpoint_function( | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/site-packages/fastapi/[routing.py](http://routing.py/)", line 212, in run_endpoint_function | return await [dependant.call](http://dependant.call/)(**values) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/hyperion/app/core/users/endpoints_[users.py](http://users.py/)", line 547, in recover_user | send_email( | File "/hyperion/app/utils/mail/[mailworker.py](http://mailworker.py/)", line 43, in send_email | server.send_message(msg, settings.SMTP_EMAIL, recipient) | File "/usr/local/lib/python3.11/[smtplib.py](http://smtplib.py/)", line 986, in send_message | return self.sendmail(from_addr, to_addrs, flatmsg, mail_options, | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | File "/usr/local/lib/python3.11/[smtplib.py](http://smtplib.py/)", line 901, in sendmail | raise SMTPRecipientsRefused(senderrs) | smtplib.SMTPRecipientsRefused: {'': (501, b'5.5.4 Invalid TO: Null path not allowed')} +------------------------------------ During handling of the above exception, another exception occurred: Traceback (most recent call last): File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_[impl.py](http://impl.py/)", line 401, in run_asgi result = await app( # type: ignore[func-returns-value] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_[headers.py](http://headers.py/)", line 70, in __call__ return await [self.app](http://self.app/)(scope, receive, send) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/site-packages/fastapi/[applications.py](http://applications.py/)", line 1054, in __call__ await super().__call__(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/[applications.py](http://applications.py/)", line 113, in __call__ await self.middleware_stack(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[errors.py](http://errors.py/)", line 187, in __call__ raise exc File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[errors.py](http://errors.py/)", line 165, in __call__ await [self.app](http://self.app/)(scope, receive, _send) File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 185, in __call__ with collapse_excgroups(): File "/usr/local/lib/python3.11/[contextlib.py](http://contextlib.py/)", line 158, in __exit__ self.gen.throw(typ, value, traceback) File "/usr/local/lib/python3.11/site-packages/starlette/_[utils.py](http://utils.py/)", line 82, in collapse_excgroups raise exc File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 187, in __call__ response = await self.dispatch_func(request, call_next) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/hyperion/app/[app.py](http://app.py/)", line 500, in logging_middleware response = await call_next(request) ^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 163, in call_next raise app_exc File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[base.py](http://base.py/)", line 149, in coro await [self.app](http://self.app/)(scope, receive_or_disconnect, send_no_error) File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[cors.py](http://cors.py/)", line 85, in __call__ await [self.app](http://self.app/)(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/middleware/[exceptions.py](http://exceptions.py/)", line 62, in __call__ await wrap_app_handling_exceptions([self.app](http://self.app/), conn)(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 53, in wrapped_app raise exc File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 42, in wrapped_app await app(scope, receive, sender) File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 715, in __call__ await self.middleware_stack(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 735, in app await route.handle(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 288, in handle await [self.app](http://self.app/)(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 76, in app await wrap_app_handling_exceptions(app, request)(scope, receive, send) File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 53, in wrapped_app raise exc File "/usr/local/lib/python3.11/site-packages/starlette/_exception_[handler.py](http://handler.py/)", line 42, in wrapped_app await app(scope, receive, sender) File "/usr/local/lib/python3.11/site-packages/starlette/[routing.py](http://routing.py/)", line 73, in app response = await f(request) ^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/site-packages/fastapi/[routing.py](http://routing.py/)", line 301, in app raw_response = await run_endpoint_function( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/site-packages/fastapi/[routing.py](http://routing.py/)", line 212, in run_endpoint_function return await [dependant.call](http://dependant.call/)(**values) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/hyperion/app/core/users/endpoints_[users.py](http://users.py/)", line 547, in recover_user send_email( File "/hyperion/app/utils/mail/[mailworker.py](http://mailworker.py/)", line 43, in send_email server.send_message(msg, settings.SMTP_EMAIL, recipient) File "/usr/local/lib/python3.11/[smtplib.py](http://smtplib.py/)", line 986, in send_message return self.sendmail(from_addr, to_addrs, flatmsg, mail_options, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.11/[smtplib.py](http://smtplib.py/)", line 901, in sendmail raise SMTPRecipientsRefused(senderrs) smtplib.SMTPRecipientsRefused: {'': (501, b'5.5.4 Invalid TO: Null path not allowed')}

Instead of an infinitely clearer straight-to-the-point one-liner that would'nt mess around with our logs monitoring:
>uvicorn.error - ERROR - Bad email adress: "". For mail with subject "MyECL - reset your password".