### PR TITLE
CdR: get the tickets generators of a product

### DIFF
--- a/app/modules/cdr/cruds_cdr.py
+++ b/app/modules/cdr/cruds_cdr.py
@@ -797,6 +797,18 @@ async def get_ticket_by_secret(
     return result.scalars().first()
 
 
+async def get_product_ticket_generators(
+    db: AsyncSession,
+    product_id: UUID,
+) -> Sequence[models_cdr.TicketGenerator]:
+    result = await db.execute(
+        select(models_cdr.TicketGenerator).where(
+            models_cdr.TicketGenerator.product_id == product_id,
+        ),
+    )
+    return result.scalars().all()
+
+
 async def scan_ticket(db: AsyncSession, ticket_id: UUID, scan: int, tags: str):
     await db.execute(
         update(models_cdr.Ticket)

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2545,11 +2545,11 @@ async def get_ticket_secret(
 
 
 @module.router.get(
-    "/cdr/sellers/{seller_id}/products/{product_id}/ticket/",
+    "/cdr/sellers/{seller_id}/products/{product_id}/tickets/",
     response_model=list[schemas_cdr.GenerateProductTicket],
     status_code=200,
 )
-async def get_tickets(
+async def get_tickets_generators_by_product(
     seller_id: UUID,
     product_id: UUID,
     db: AsyncSession = Depends(get_db),

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2545,6 +2545,26 @@ async def get_ticket_secret(
 
 
 @module.router.get(
+    "/cdr/sellers/{seller_id}/products/{product_id}/ticket/",
+    response_model=list[schemas_cdr.GenerateProductTicket],
+    status_code=200,
+)
+async def get_tickets(
+    seller_id: UUID,
+    product_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    user: models_users.CoreUser = Depends(is_user_a_member),
+):
+    await is_user_in_a_seller_group(
+        seller_id,
+        user,
+        db=db,
+    )
+    await check_request_consistency(db=db, seller_id=seller_id, product_id=product_id)
+    return await cruds_cdr.get_product_ticket_generators(db=db, product_id=product_id)
+
+
+@module.router.get(
     "/cdr/sellers/{seller_id}/products/{product_id}/tickets/{generator_id}/{secret}/",
     response_model=schemas_cdr.Ticket,
     status_code=200,

--- a/app/modules/cdr/schemas_cdr.py
+++ b/app/modules/cdr/schemas_cdr.py
@@ -85,6 +85,10 @@ class GenerateTicketEdit(BaseModel):
     expiration: datetime | None = None
 
 
+class GenerateProductTicket(GenerateTicketComplete):
+    product_id: UUID
+
+
 class ProductVariantBase(BaseModel):
     name_fr: str
     name_en: str | None = None


### PR DESCRIPTION
### Description

When editing a product on Siarnaq, we need to get the tickets generators associated to this product (now in the plural!), much like we already do for the custom questions to users (so-called "data fields").

### Checklist

- [x] Created an endpoint
- [x] Sort of created a schema for the response
- [x] Created a CRUD, fortunately using an existing model: the work is already done on the db side, this PR merely creates an interface to get a specific list
