### PR TITLE
Only hash a global password for all test users

### DIFF
--- a/tests/commons.py
+++ b/tests/commons.py
@@ -155,6 +155,8 @@ TestingSessionLocal = async_sessionmaker(
 
 hyperion_error_logger = logging.getLogger("hyperion.error")
 
+TEST_PASSWORD_HASH = security.get_password_hash(get_random_string())
+
 
 async def create_user_with_groups(
     groups: list[GroupType],
@@ -176,7 +178,9 @@ async def create_user_with_groups(
     """
 
     user_id = user_id or str(uuid.uuid4())
-    password_hash = security.get_password_hash(password or get_random_string())
+    password_hash = (
+        security.get_password_hash(password) if password else TEST_PASSWORD_HASH
+    )
     school_id = school_id.value if isinstance(school_id, SchoolType) else school_id
 
     user = models_users.CoreUser(


### PR DESCRIPTION
as hashing password is a time consuming operation. We expect a 2 min gain over our test suite.