### PR TITLE
Make CdR coredata public

### DIFF
--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2545,7 +2545,6 @@ async def get_payment_url(
 )
 async def get_cdr_year(
     db: AsyncSession = Depends(get_db),
-    user: models_users.CoreUser = Depends(is_user()),
 ):
     return await get_core_data(coredata_cdr.CdrYear, db)
 
@@ -2569,7 +2568,6 @@ async def update_cdr_year(
 )
 async def get_status(
     db: AsyncSession = Depends(get_db),
-    user: models_users.CoreUser = Depends(is_user()),
 ):
     return await get_core_data(schemas_cdr.Status, db)
 


### PR DESCRIPTION
* No reason to hide it
* Purpose: display the cdr year in Siarnaq :
  * in order not to hard-code it (changing it every year is bad)
  * in order to know easily the year Siarnaq thinks it is and catch it early if wrong
* Possibly do the same with the status (for the same reasons: pretty annoying to have to use admin rights to be sure of the actual status)