### PR TITLE
Fix(state management): store state in global variable to allow the sc…

### DIFF
--- a/app/core/notification/endpoints_notification.py
+++ b/app/core/notification/endpoints_notification.py
@@ -299,7 +299,7 @@ async def send_test_future_notification(
         message=message,
         defer_date=datetime.now(UTC) + timedelta(seconds=10),
         scheduler=scheduler,
-        job_id="testtt",
+        job_id="send_test_future_notification",
     )
 
 
@@ -350,7 +350,7 @@ async def send_test_future_notification_topic(
         topic_id=notification_test_topic.id,
         message=message,
         defer_date=datetime.now(UTC) + timedelta(seconds=10),
-        job_id="test26",
+        job_id="notification_test_future",
         scheduler=scheduler,
     )
 

--- a/app/types/scheduler.py
+++ b/app/types/scheduler.py
@@ -6,7 +6,7 @@ from inspect import signature
 from typing import TYPE_CHECKING, Any
 
 from arq.connections import RedisSettings
-from arq.jobs import Job
+from arq.jobs import Job, JobStatus
 from arq.typing import WorkerSettingsBase
 from arq.worker import create_worker
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,11 +57,12 @@ async def run_task(
     if require_db_for_kwargs:
         # `get_db` is the real dependency, defined in dependency.py
         # `_get_db` may be the real dependency or an override
-        _get_db: Callable[[], AsyncGenerator[AsyncSession, None]] = (
-            _dependency_overrides.get(
-                dependencies.get_db,
-                dependencies.get_db,
-            )
+        _get_db: Callable[
+            [],
+            AsyncGenerator[AsyncSession, None],
+        ] = _dependency_overrides.get(
+            dependencies.get_db,
+            dependencies.get_db,
         )
 
         async for db in _get_db():
@@ -110,7 +111,10 @@ class Scheduler:
         class ArqWorkerSettings(WorkerSettingsBase):
             functions = [run_task]
             allow_abort_jobs = True
-            keep_result_forever = True
+            # After a job is completed or aborted, we want arq to remove its result
+            # to be able to queue a new task with the same id
+            keep_result = 0
+            keep_result_forever = False
             redis_settings = RedisSettings(
                 host=redis_host,
                 port=redis_port,
@@ -167,8 +171,13 @@ class Scheduler:
         if self.worker is None:
             raise SchedulerNotStartedError
         job = Job(job_id, redis=self.worker.pool)
-        scheduler_logger.debug(f"Job aborted {job}")
-        await job.abort()
+        # We only want to abort the job if it exist
+        # otherwise if we try to plan a job with the same id just after, we may get
+        # a job aborted before being queued
+        status = await job.status()
+        if status != JobStatus.not_found:
+            scheduler_logger.debug(f"Job being aborted {job}")
+            await job.abort()
 
 
 class OfflineScheduler(Scheduler):
@@ -200,7 +209,6 @@ class OfflineScheduler(Scheduler):
         - redis_password: str
         - _dependency_overrides: dict[Callable[..., Any], Callable[..., Any]] a pointer to the app dependency overrides dict
         """
-        self._dependency_overrides = _dependency_overrides
 
         scheduler_logger.info("OfflineScheduler started")
 

--- a/app/types/sqlalchemy.py
+++ b/app/types/sqlalchemy.py
@@ -1,12 +1,18 @@
 import datetime
 import uuid
+from collections.abc import Callable
 from typing import Annotated
 
 from sqlalchemy import DateTime, types
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+)
 from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, mapped_column
 from sqlalchemy.types import TypeDecorator
 
 from app.types.exceptions import MissingTZInfoInDatetimeError
+
+SessionLocalType = Callable[[], AsyncSession]
 
 
 class TZDateTime(TypeDecorator):

--- a/app/utils/communication/notifications.py
+++ b/app/utils/communication/notifications.py
@@ -424,6 +424,7 @@ class NotificationTool:
         defer_date: datetime,
         job_id: str,
     ):
+        await scheduler.cancel_job(job_id=job_id)
         await scheduler.queue_job_defer_to(
             self.notification_manager.send_notification_to_users,
             user_ids=user_ids,
@@ -473,6 +474,7 @@ class NotificationTool:
         defer_date: datetime,
         job_id: str,
     ):
+        await scheduler.cancel_job(job_id=job_id)
         await scheduler.queue_job_defer_to(
             self.notification_manager.send_notification_to_topic,
             topic_id=topic_id,

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,6 +1,6 @@
 aiofiles==24.1.0                    # Asynchronous file manipulation
 alembic==1.13.2                     # database migrations
-arq==0.26.1                         # Scheduler 
+arq==0.26.3                         # Scheduler 
 asyncpg==0.29.0                     # PostgreSQL adapter for asynchronous operations
 authlib==1.5.2
 bcrypt==4.1.3                       # password hashing

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -1,6 +1,5 @@
 import logging
 import uuid
-from collections.abc import Callable
 from datetime import timedelta
 from functools import lru_cache
 
@@ -13,6 +12,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from app import dependencies
 from app.core.auth import schemas_auth
 from app.core.groups import cruds_groups, models_groups
 from app.core.groups.groups_type import AccountType, GroupType
@@ -27,10 +27,10 @@ from app.modules.raid.utils.drive.drive_file_manager import DriveFileManager
 from app.types import core_data
 from app.types.floors_type import FloorsType
 from app.types.scheduler import OfflineScheduler
-from app.types.sqlalchemy import Base
+from app.types.sqlalchemy import Base, SessionLocalType
 from app.utils.communication.notifications import NotificationManager
 from app.utils.state import (
-    LifespanState,
+    GlobalState,
     init_mail_templates,
     init_redis_client,
     init_websocket_connection_manager,
@@ -45,17 +45,18 @@ class FailedToAddObjectToDB(Exception):
     """Exception raised when an object cannot be added to the database."""
 
 
-async def override_init_app_state(
+async def override_init_state(
     app: FastAPI,
     settings: Settings,
     hyperion_error_logger: logging.Logger,
-) -> LifespanState:
+) -> None:
     """
     Initialize the state of the application. This dependency should be used at the start of the application lifespan.
     """
-    engine = init_test_engine()
 
-    SessionLocal = init_test_SessionLocal()
+    engine = init_test_engine(settings=settings)
+
+    SessionLocal = init_test_SessionLocal(engine=engine)
 
     redis_client = init_redis_client(
         settings=settings,
@@ -79,7 +80,7 @@ async def override_init_app_state(
 
     mail_templates = init_mail_templates(settings=settings)
 
-    return LifespanState(
+    dependencies.GLOBAL_STATE = GlobalState(
         engine=engine,
         SessionLocal=SessionLocal,
         redis_client=redis_client,
@@ -92,56 +93,64 @@ async def override_init_app_state(
     )
 
 
-@lru_cache
-def get_override_get_settings(**kwargs) -> Callable[[], Settings]:
+def create_test_settings(**kwargs) -> Settings:
     """Override the get_settings function to use the testing session"""
 
-    def override_get_settings() -> Settings:
-        return Settings(
-            _env_file="./tests/.env.test",
-            _yaml_file="./tests/config.test.yaml",
-            **kwargs,
-        )
-
-    return override_get_settings
+    return Settings(
+        _env_file="./tests/.env.test",
+        _yaml_file="./tests/config.test.yaml",
+        **kwargs,
+    )
 
 
-settings = get_override_get_settings()()
+# We use a global `SETTINGS` and a global `TestingSessionLocal` object
+# to be able to access it from tests
+SETTINGS: Settings
+TestingSessionLocal: SessionLocalType
 
 
-# Connect to the test's database
-if settings.SQLITE_DB:
-    SQLALCHEMY_DATABASE_URL = f"sqlite+aiosqlite:///./{settings.SQLITE_DB}"
-    SQLALCHEMY_DATABASE_URL_SYNC = f"sqlite:///./{settings.SQLITE_DB}"
-else:
-    SQLALCHEMY_DATABASE_URL = f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
-    SQLALCHEMY_DATABASE_URL_SYNC = f"postgresql+psycopg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
+@lru_cache
+def override_get_settings() -> Settings:
+    return SETTINGS  # noqa: F821
 
 
-engine = create_async_engine(
-    SQLALCHEMY_DATABASE_URL,
-    echo=settings.DATABASE_DEBUG,
-    # We need to use NullPool to run tests with Postgresql
-    # See https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops
-    poolclass=NullPool,
-)
-
-TestingSessionLocal = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
+def get_TestingSessionLocal() -> SessionLocalType:
+    return TestingSessionLocal
 
 
-def init_test_engine() -> AsyncEngine:
+def get_database_sync_url() -> str:
+    settings = override_get_settings()
+    if settings.SQLITE_DB:
+        return f"sqlite:///./{settings.SQLITE_DB}"
+    return f"postgresql+psycopg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
+
+
+def init_test_engine(settings: Settings) -> AsyncEngine:
     """
     Return the (asynchronous) database engine, if the engine doesn't exit yet it will create one based on the settings
     """
+    # Connect to the test's database
+    if settings.SQLITE_DB:
+        SQLALCHEMY_DATABASE_URL = f"sqlite+aiosqlite:///./{settings.SQLITE_DB}"
+    else:
+        SQLALCHEMY_DATABASE_URL = f"postgresql+asyncpg://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}/{settings.POSTGRES_DB}"
 
-    return engine
+    return create_async_engine(
+        SQLALCHEMY_DATABASE_URL,
+        echo=settings.DATABASE_DEBUG,
+        # We need to use NullPool to run tests with Postgresql
+        # See https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops
+        poolclass=NullPool,
+    )
 
 
-def init_test_SessionLocal() -> Callable[[], AsyncSession]:
+def init_test_SessionLocal(engine: AsyncEngine) -> SessionLocalType:
+    global TestingSessionLocal
+    TestingSessionLocal = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
     return TestingSessionLocal
 
 
@@ -151,14 +160,6 @@ def init_test_payment_tools() -> dict[HelloAssoConfigName, PaymentTool]:
         payment_tools[helloasso_config_name] = MockedPaymentTool()
 
     return payment_tools
-
-
-# Create a session for testing purposes
-TestingSessionLocal = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
 
 
 hyperion_error_logger = logging.getLogger("hyperion.error")
@@ -244,7 +245,7 @@ def create_api_access_token(
     access_token_data = schemas_auth.TokenData(sub=user.id, scopes="API")
     return security.create_access_token(
         data=access_token_data,
-        settings=settings,
+        settings=override_get_settings(),
         expires_delta=expires_delta,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,44 +6,46 @@ from fastapi.testclient import TestClient
 from app.app import get_application
 from app.dependencies import (
     get_settings,
-    init_app_state,
+    init_state,
 )
+from tests import commons
 from tests.commons import (
-    get_override_get_settings,
-    override_init_app_state,
-    settings,
+    create_test_settings,
+    override_get_settings,
+    override_init_state,
 )
 
 
 @pytest.fixture(scope="module", autouse=True)
-def client() -> Generator[TestClient, None, None]:
-    test_app = get_application(settings=settings, drop_db=True)  # Create the test's app
+def client(request) -> Generator[TestClient, None, None]:
+    """
+    TestClient fixture.
 
-    test_app.dependency_overrides[init_app_state] = override_init_app_state
-    test_app.dependency_overrides[get_settings] = get_override_get_settings()
+    A parameter `use_attribute` can be passed to the fixture using:
+    ```python
+    @pytest.mark.parametrize("client", [True], indirect=True)
+    async def test_example(client: TestClient):
+        ...
+    ```
+    """
+    try:
+        use_factory = request.__getattribute__("param")
+    except AttributeError:
+        use_factory = False
+
+    commons.SETTINGS = create_test_settings(
+        USE_FACTORIES=use_factory,
+    )
+
+    test_app = get_application(
+        settings=commons.SETTINGS,
+        drop_db=True,
+    )  # Create the test's app
+
+    test_app.dependency_overrides[init_state] = override_init_state
+    test_app.dependency_overrides[get_settings] = override_get_settings
 
     # The TestClient should be used as a context manager in order for the lifespan to be called
     # See https://www.starlette.io/lifespan/#running-lifespan-in-tests
     with TestClient(test_app) as client:
-        yield client
-
-
-@pytest.fixture(scope="module")
-def factory_running_client() -> Generator[TestClient, None]:
-    """
-    This fixture is used to create the FastAPI application instance for testing.
-    It sets up the application with the necessary dependencies and configurations.
-    """
-    override_get_settings = get_override_get_settings(
-        USE_FACTORIES=True,
-    )
-    test_app = get_application(
-        settings=override_get_settings(),
-        drop_db=True,
-    )
-    test_app.dependency_overrides[init_app_state] = override_init_app_state
-    test_app.dependency_overrides[get_settings] = override_get_settings
-
-    with TestClient(test_app) as client:
-        # Set the base URL for the test client
         yield client

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,11 +1,13 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.module import all_modules
-from tests.commons import TestingSessionLocal
+from tests.commons import get_TestingSessionLocal
 
 
-async def test_factories(factory_running_client: TestClient) -> None:
-    async with TestingSessionLocal() as db:
+@pytest.mark.parametrize("client", [True], indirect=True)
+async def test_factories(client: TestClient) -> None:
+    async with get_TestingSessionLocal()() as db:
         factories = [
             module.factory for module in all_modules if module.factory is not None
         ]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Connection
 
 from app.utils.initialization import drop_db_sync
-from tests.commons import SQLALCHEMY_DATABASE_URL_SYNC
+from tests.commons import get_database_sync_url
 
 pre_test_upgrade_dict: dict[
     str,
@@ -103,6 +103,7 @@ def alembic_connection() -> Generator[Connection, None, None]:
     """
     # We use `echo=False` to disable SQLAlchemy logging for migrations
     # as errors are easier to see without all SQLAlchemy info
+    SQLALCHEMY_DATABASE_URL_SYNC = get_database_sync_url()
     connectable = create_engine(SQLALCHEMY_DATABASE_URL_SYNC, echo=False)
 
     with connectable.begin() as connection:

--- a/tests/test_myeclpay.py
+++ b/tests/test_myeclpay.py
@@ -25,10 +25,10 @@ from app.core.myeclpay.types_myeclpay import (
 from app.core.myeclpay.utils_myeclpay import LATEST_TOS
 from app.core.users import models_users
 from tests.commons import (
-    TestingSessionLocal,
     add_object_to_db,
     create_api_access_token,
     create_user_with_groups,
+    get_TestingSessionLocal,
 )
 
 admin_user: models_users.CoreUser
@@ -1539,7 +1539,7 @@ async def test_create_and_activate_user_device(
     assert response.status_code == 201
     assert response.json()["id"] is not None
 
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         wallet_device = await db.get(
             models_myeclpay.WalletDevice,
             response.json()["id"],
@@ -2312,8 +2312,8 @@ async def test_store_scan_store_successful_scan(client: TestClient):
         qr_code_content.model_dump_json().encode("utf-8"),
     )
 
-    async with TestingSessionLocal() as db:
-        store_wallet_before_scan = await cruds_myeclpay.get_wallet(
+    async with get_TestingSessionLocal()() as db:
+        store_wallet_before_scan = await cruds_mypayment.get_wallet(
             db=db,
             wallet_id=store_wallet.id,
         )
@@ -2340,8 +2340,8 @@ async def test_store_scan_store_successful_scan(client: TestClient):
 
     ensure_qr_code_id_is_already_used(qr_code_id=qr_code_id, client=client)
 
-    async with TestingSessionLocal() as db:
-        store_wallet_after_scan = await cruds_myeclpay.get_wallet(
+    async with get_TestingSessionLocal()() as db:
+        store_wallet_after_scan = await cruds_mypayment.get_wallet(
             db=db,
             wallet_id=store_wallet.id,
         )
@@ -2415,8 +2415,8 @@ async def test_transaction_refund_unauthorized_user(client: TestClient):
 
 
 async def test_transaction_refund_complete(client: TestClient):
-    async with TestingSessionLocal() as db:
-        debited_wallet_before_refund = await cruds_myeclpay.get_wallet(
+    async with get_TestingSessionLocal()() as db:
+        debited_wallet_before_refund = await cruds_mypayment.get_wallet(
             db=db,
             wallet_id=ecl_user_wallet.id,
         )
@@ -2450,8 +2450,8 @@ async def test_transaction_refund_complete(client: TestClient):
     )
     assert response.status_code == 204
 
-    async with TestingSessionLocal() as db:
-        transaction_after_refund = await cruds_myeclpay.get_transaction(
+    async with get_TestingSessionLocal()() as db:
+        transaction_after_refund = await cruds_mypayment.get_transaction(
             db=db,
             transaction_id=transaction.id,
         )
@@ -2535,8 +2535,8 @@ async def test_transaction_refund_partial_invalid_amount(client: TestClient):
 
 
 async def test_transaction_refund_partial(client: TestClient):
-    async with TestingSessionLocal() as db:
-        debited_wallet_before_refund = await cruds_myeclpay.get_wallet(
+    async with get_TestingSessionLocal()() as db:
+        debited_wallet_before_refund = await cruds_mypayment.get_wallet(
             db=db,
             wallet_id=ecl_user_wallet.id,
         )
@@ -2573,8 +2573,8 @@ async def test_transaction_refund_partial(client: TestClient):
     )
     assert response.status_code == 204
 
-    async with TestingSessionLocal() as db:
-        transaction_after_refund = await cruds_myeclpay.get_transaction(
+    async with get_TestingSessionLocal()() as db:
+        transaction_after_refund = await cruds_mypayment.get_transaction(
             db=db,
             transaction_id=transaction.id,
         )

--- a/tests/test_myeclpay.py
+++ b/tests/test_myeclpay.py
@@ -2313,7 +2313,7 @@ async def test_store_scan_store_successful_scan(client: TestClient):
     )
 
     async with get_TestingSessionLocal()() as db:
-        store_wallet_before_scan = await cruds_mypayment.get_wallet(
+        store_wallet_before_scan = await cruds_myeclpay.get_wallet(
             db=db,
             wallet_id=store_wallet.id,
         )
@@ -2341,7 +2341,7 @@ async def test_store_scan_store_successful_scan(client: TestClient):
     ensure_qr_code_id_is_already_used(qr_code_id=qr_code_id, client=client)
 
     async with get_TestingSessionLocal()() as db:
-        store_wallet_after_scan = await cruds_mypayment.get_wallet(
+        store_wallet_after_scan = await cruds_myeclpay.get_wallet(
             db=db,
             wallet_id=store_wallet.id,
         )
@@ -2416,7 +2416,7 @@ async def test_transaction_refund_unauthorized_user(client: TestClient):
 
 async def test_transaction_refund_complete(client: TestClient):
     async with get_TestingSessionLocal()() as db:
-        debited_wallet_before_refund = await cruds_mypayment.get_wallet(
+        debited_wallet_before_refund = await cruds_myeclpay.get_wallet(
             db=db,
             wallet_id=ecl_user_wallet.id,
         )
@@ -2451,7 +2451,7 @@ async def test_transaction_refund_complete(client: TestClient):
     assert response.status_code == 204
 
     async with get_TestingSessionLocal()() as db:
-        transaction_after_refund = await cruds_mypayment.get_transaction(
+        transaction_after_refund = await cruds_myeclpay.get_transaction(
             db=db,
             transaction_id=transaction.id,
         )
@@ -2536,7 +2536,7 @@ async def test_transaction_refund_partial_invalid_amount(client: TestClient):
 
 async def test_transaction_refund_partial(client: TestClient):
     async with get_TestingSessionLocal()() as db:
-        debited_wallet_before_refund = await cruds_mypayment.get_wallet(
+        debited_wallet_before_refund = await cruds_myeclpay.get_wallet(
             db=db,
             wallet_id=ecl_user_wallet.id,
         )
@@ -2574,7 +2574,7 @@ async def test_transaction_refund_partial(client: TestClient):
     assert response.status_code == 204
 
     async with get_TestingSessionLocal()() as db:
-        transaction_after_refund = await cruds_mypayment.get_transaction(
+        transaction_after_refund = await cruds_myeclpay.get_transaction(
             db=db,
             transaction_id=transaction.id,
         )

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -22,9 +22,9 @@ from app.core.users import schemas_users
 from app.types.module import Module
 from tests.commons import (
     MockedPaymentTool,
-    TestingSessionLocal,
     add_object_to_db,
     create_user_with_groups,
+    get_TestingSessionLocal,
 )
 
 if TYPE_CHECKING:
@@ -243,8 +243,8 @@ async def test_webhook_payment(
 
     assert response.status_code == 204
 
-    async with TestingSessionLocal() as db:
-        checkout_model = await cruds_payment.get_checkout_by_id(
+    async with get_TestingSessionLocal()() as db:
+        checkout_model = await cruds_checkout.get_checkout_by_id(
             checkout_id=checkout.id,
             db=db,
         )
@@ -269,8 +269,8 @@ async def test_webhook_payment(
 
     assert response.status_code == 204
 
-    async with TestingSessionLocal() as db:
-        checkout_model = await cruds_payment.get_checkout_by_id(
+    async with get_TestingSessionLocal()() as db:
+        checkout_model = await cruds_checkout.get_checkout_by_id(
             checkout_id=checkout.id,
             db=db,
         )
@@ -387,7 +387,7 @@ async def test_payment_tool_get_checkout(
 ):
     payment_tool = MockedPaymentTool()
 
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         # Get existing checkout
         existing_checkout = await payment_tool.get_checkout(
             checkout_id=checkout_with_existing_checkout_payment.id,
@@ -443,7 +443,7 @@ async def test_payment_tool_init_checkout(
         return_value=mock_checkout_api,
     )
 
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         returned_checkout = await payment_tool.init_checkout(
             module="testtool",
             checkout_amount=100,
@@ -518,7 +518,7 @@ async def test_payment_tool_init_checkout_with_one_failure(
         return_value=mock_checkout_api,
     )
 
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         returned_checkout = await payment_tool.init_checkout(
             module="testtool",
             checkout_amount=100,
@@ -584,7 +584,7 @@ async def test_payment_tool_init_checkout_fail(
     )
 
     with pytest.raises(ValueError, match="Mocked Exception"):
-        async with TestingSessionLocal() as db:
+        async with get_TestingSessionLocal()() as db:
             await payment_tool.init_checkout(
                 module="testtool",
                 checkout_amount=100,

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -244,7 +244,7 @@ async def test_webhook_payment(
     assert response.status_code == 204
 
     async with get_TestingSessionLocal()() as db:
-        checkout_model = await cruds_checkout.get_checkout_by_id(
+        checkout_model = await cruds_payment.get_checkout_by_id(
             checkout_id=checkout.id,
             db=db,
         )
@@ -270,7 +270,7 @@ async def test_webhook_payment(
     assert response.status_code == 204
 
     async with get_TestingSessionLocal()() as db:
-        checkout_model = await cruds_checkout.get_checkout_by_id(
+        checkout_model = await cruds_payment.get_checkout_by_id(
             checkout_id=checkout.id,
             db=db,
         )

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,17 +1,19 @@
 from fastapi.testclient import TestClient
 
-from tests.commons import settings
+from tests import commons
 
 
 def test_limiter(client: TestClient) -> None:
     # Enable the rate limiter for this test
-    settings.ENABLE_RATE_LIMITER = True
+
+    initial_ENABLE_RATE_LIMITER = commons.SETTINGS.ENABLE_RATE_LIMITER
+    commons.SETTINGS.ENABLE_RATE_LIMITER = True
     try:
-        for _ in range(settings.REDIS_LIMIT - 1):
+        for _ in range(commons.SETTINGS.REDIS_LIMIT - 1):
             response = client.get("/information")
             assert response.status_code == 200
         for _ in range(2):
             response = client.get("/information")
             assert response.status_code == 429
     finally:
-        settings.ENABLE_RATE_LIMITER = False
+        commons.SETTINGS.ENABLE_RATE_LIMITER = initial_ENABLE_RATE_LIMITER

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,8 @@ from app.utils.tools import (
     set_core_data,
 )
 from tests.commons import (
-    TestingSessionLocal,
     add_object_to_db,
+    get_TestingSessionLocal,
 )
 
 
@@ -250,14 +250,14 @@ async def test_save_pdf_first_page_as_image() -> None:
 
 
 async def test_get_core_data() -> None:
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         exemple_core_data = await get_core_data(core_data_class=ExempleCoreData, db=db)
         assert exemple_core_data.name == "Fabristpp"
         assert exemple_core_data.age == 42
 
 
 async def test_get_default_core_data() -> None:
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         default_core_data = await get_core_data(
             core_data_class=ExempleDefaultCoreData,
             db=db,
@@ -267,7 +267,7 @@ async def test_get_default_core_data() -> None:
 
 
 async def test_get_default_without_default_values_core_data():
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         with pytest.raises(CoreDataNotFoundError):
             await get_core_data(
                 core_data_class=ExempleDefaultWithoutDefaultValuesCoreData,
@@ -276,7 +276,7 @@ async def test_get_default_without_default_values_core_data():
 
 
 async def test_replace_core_data() -> None:
-    async with TestingSessionLocal() as db:
+    async with get_TestingSessionLocal()() as db:
         core_data = ExempleExistingCoreData(
             name="ECLAIR",
             age=42,


### PR DESCRIPTION
…heduler to access db (backport of https://github.com/ProximApp/Hyperion/pull/8)

* Fix user batch invitation response model

* Fix: add missing param in send_emails_from_queue_task

* Get db directly using SessionLocal

* Store state in global Python variable

* Use arq 0.26.3

* Don't keep arq job results after completion

to be able to queue new jobs with the same id

* Cancel planned notification with the same job_id

before queuing a new one

* fixup state

* Access GLOBAL_STATE in tests init

* Remove unexpected state param while disconnecting

* Lint

* Parametrize test_factory fixture

* Lint

* Refactor test settings