### PR TITLE
Fix non-embedded body in sport endpoint

### DIFF
--- a/app/modules/sport_competition/endpoints_sport_competition.py
+++ b/app/modules/sport_competition/endpoints_sport_competition.py
@@ -258,7 +258,7 @@ async def enable_inscription(
     user: models_users.CoreUser = Depends(
         is_user_allowed_to([SportCompetitionPermissions.manage_sport_competition]),
     ),
-    enable: bool = Body(),
+    enable: bool = Body(embed=True),
 ) -> None:
     """
     Enable inscription for a competition edition.


### PR DESCRIPTION
Fix: possibly the only endpoint in codebase that didn't embed it's body in a JSON