### PR TITLE
Rewrite init_checkout for robustness and logging

### DIFF
--- a/app/core/mypayment/endpoints_mypayment.py
+++ b/app/core/mypayment/endpoints_mypayment.py
@@ -1260,7 +1260,7 @@ async def register_user(
         accepted_tos_version=0,
         db=db,
     )
-    db.flush()
+    await db.flush()
 
     hyperion_mypayment_logger.info(
         wallet_id,

--- a/app/core/mypayment/endpoints_mypayment.py
+++ b/app/core/mypayment/endpoints_mypayment.py
@@ -1894,27 +1894,17 @@ async def init_ha_transfer(
             detail="Wallet balance would exceed the maximum allowed balance",
         )
 
-    user_schema = schemas_users.CoreUser(
-        account_type=user.account_type,
-        school_id=user.school_id,
-        email=user.email,
-        birthday=user.birthday,
-        promo=user.promo,
-        floor=user.floor,
-        phone=user.phone,
-        created_on=user.created_on,
-        groups=[],
-        id=user.id,
-        name=user.name,
-        firstname=user.firstname,
-        nickname=user.nickname,
-    )
     checkout = await payment_tool.init_checkout(
         module="mypayment",
         checkout_amount=transfer_info.amount,
         checkout_name=f"Recharge {settings.school.payment_name}",
         redirection_uri=f"{settings.CLIENT_URL}mypayment/transfer/redirect?url={transfer_info.redirect_url}",
-        payer_user=user_schema,
+        payer_user=schemas_payment.PayerUser(
+            firstname=user.firstname,
+            name=user.name,
+            email=user.email,
+            birthday=user.birthday,
+        ),
         db=db,
     )
 

--- a/app/core/payment/schemas_payment.py
+++ b/app/core/payment/schemas_payment.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 
 from pydantic import BaseModel, computed_field
 
@@ -38,3 +39,10 @@ class HelloAssoCheckoutMetadata(BaseModel):
 
 class PaymentUrl(BaseModel):
     url: str
+
+
+class PayerUser(BaseModel):
+    firstname: str
+    name: str
+    email: str
+    birthday: date | None = None

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -19,6 +19,7 @@ from app.core.groups import cruds_groups, schemas_groups
 from app.core.groups.groups_type import AccountType
 from app.core.memberships import cruds_memberships, schemas_memberships
 from app.core.payment.payment_tool import PaymentTool
+from app.core.payment.schemas_payment import PayerUser
 from app.core.payment.types_payment import HelloAssoConfigName
 from app.core.permissions.type_permissions import ModulePermissions
 from app.core.users import cruds_users, models_users, schemas_users
@@ -2791,33 +2792,16 @@ async def get_payment_url(
             status_code=403,
             detail="Please give an amount in cents, greater than 1€.",
         )
-    user_schema = schemas_users.CoreUser(
-        account_type=user.account_type,
-        school_id=user.school_id,
-        email=user.email,
-        birthday=user.birthday,
-        promo=user.promo,
-        floor=user.floor,
-        phone=user.phone,
-        created_on=user.created_on,
-        groups=[
-            schemas_groups.CoreGroupSimple(
-                id=group.id,
-                name=group.name,
-                description=group.description,
-            )
-            for group in user.groups
-        ],
-        id=user.id,
-        name=user.name,
-        firstname=user.firstname,
-        nickname=user.nickname,
-    )
     checkout = await payment_tool.init_checkout(
         module=module.root,
         checkout_amount=amount,
         checkout_name="Chaine de rentrée",
-        payer_user=user_schema,
+        payer_user=PayerUser(
+            firstname=user.firstname,
+            name=user.name,
+            email=user.email,
+            birthday=user.birthday,
+        ),
         db=db,
     )
     hyperion_error_logger.info(f"CDR: Logging Checkout id {checkout.id}")

--- a/app/modules/raid/endpoints_raid.py
+++ b/app/modules/raid/endpoints_raid.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.groups.groups_type import AccountType
 from app.core.payment.payment_tool import PaymentTool
+from app.core.payment.schemas_payment import PayerUser
 from app.core.payment.types_payment import HelloAssoConfigName
 from app.core.permissions.type_permissions import ModulePermissions
 from app.core.users import models_users, schemas_users
@@ -967,13 +968,16 @@ async def get_payment_url(
     if not participant:
         raise HTTPException(status_code=403, detail="You are not a participant.")
     price, checkout_name = calculate_raid_payment(participant, raid_prices)
-    user_dict = user.__dict__
-    user_dict.pop("school", None)
     checkout = await payment_tool.init_checkout(
         module=module.root,
         checkout_amount=price,
         checkout_name=checkout_name,
-        payer_user=schemas_users.CoreUser(**user_dict),
+        payer_user=PayerUser(
+            firstname=user.firstname,
+            name=user.name,
+            email=user.email,
+            birthday=user.birthday,
+        ),
         db=db,
     )
     hyperion_error_logger.info(f"RAID: Logging Checkout id {checkout.id}")

--- a/app/modules/raid/endpoints_raid.py
+++ b/app/modules/raid/endpoints_raid.py
@@ -968,19 +968,23 @@ async def get_payment_url(
     if not participant:
         raise HTTPException(status_code=403, detail="You are not a participant.")
     price, checkout_name = calculate_raid_payment(participant, raid_prices)
-    checkout = await payment_tool.init_checkout(
-        module=module.root,
-        checkout_amount=price,
-        checkout_name=checkout_name,
-        payer_user=PayerUser(
-            firstname=user.firstname,
-            name=user.name,
-            email=user.email,
-            birthday=user.birthday,
-        ),
-        db=db,
-    )
+    try:
+        checkout = await payment_tool.init_checkout(
+            module=module.root,
+            checkout_amount=price,
+            checkout_name=checkout_name,
+            payer_user=PayerUser(
+                firstname=user.firstname,
+                name=user.name,
+                email=user.email,
+                birthday=user.birthday,
+            ),
+            db=db,
+        )
+    except Exception:
+        raise HTTPException(status_code=502, detail="Cannot init the checkout")
     hyperion_error_logger.info(f"RAID: Logging Checkout id {checkout.id}")
+
     await cruds_raid.create_participant_checkout(
         models_raid.RaidParticipantCheckout(
             id=str(uuid.uuid4()),

--- a/app/modules/sport_competition/endpoints_sport_competition.py
+++ b/app/modules/sport_competition/endpoints_sport_competition.py
@@ -4082,19 +4082,24 @@ async def get_payment_url(
             status_code=403,
             detail="Please give an amount in cents, greater than 1€.",
         )
-    checkout = await payment_tool.init_checkout(
-        module=module.root,
-        checkout_amount=amount,
-        checkout_name=f"Challenge {edition.name}",
-        payer_user=PayerUser(
-            firstname=user.firstname,
-            name=user.name,
-            email=user.email,
-            birthday=user.birthday,
-        ),
-        db=db,
-    )
+
+    try:
+        checkout = await payment_tool.init_checkout(
+            module=module.root,
+            checkout_amount=amount,
+            checkout_name=f"Challenge {edition.name}",
+            payer_user=PayerUser(
+                firstname=user.firstname,
+                name=user.name,
+                email=user.email,
+                birthday=user.birthday,
+            ),
+            db=db,
+        )
+    except Exception:
+        raise HTTPException(status_code=502, detail="Cannot init the checkout")
     hyperion_error_logger.info(f"Competition: Logging Checkout id {checkout.id}")
+
     cruds_sport_competition.add_checkout(
         db=db,
         checkout=schemas_sport_competition.Checkout(
@@ -4104,7 +4109,6 @@ async def get_payment_url(
             checkout_id=checkout.id,
         ),
     )
-
     return schemas_sport_competition.PaymentUrl(
         url=checkout.payment_url,
     )

--- a/app/modules/sport_competition/endpoints_sport_competition.py
+++ b/app/modules/sport_competition/endpoints_sport_competition.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.groups.groups_type import get_account_types_except_externals
 from app.core.payment.payment_tool import PaymentTool
+from app.core.payment.schemas_payment import PayerUser
 from app.core.payment.types_payment import HelloAssoConfigName
 from app.core.schools import cruds_schools
 from app.core.schools.schools_type import SchoolType
@@ -4081,21 +4082,16 @@ async def get_payment_url(
             status_code=403,
             detail="Please give an amount in cents, greater than 1€.",
         )
-    user_schema = schemas_users.CoreUser(
-        account_type=user.account_type,
-        school_id=user.school_id,
-        id=user.id,
-        email=user.email,
-        name=user.name,
-        firstname=user.firstname,
-        created_on=user.created_on,
-        groups=[],
-    )
     checkout = await payment_tool.init_checkout(
         module=module.root,
         checkout_amount=amount,
         checkout_name=f"Challenge {edition.name}",
-        payer_user=user_schema,
+        payer_user=PayerUser(
+            firstname=user.firstname,
+            name=user.name,
+            email=user.email,
+            birthday=user.birthday,
+        ),
         db=db,
     )
     hyperion_error_logger.info(f"Competition: Logging Checkout id {checkout.id}")

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -21,7 +21,7 @@ from app.core.payment.payment_tool import PaymentTool
 from app.core.payment.types_payment import HelloAssoConfig, HelloAssoConfigName
 from app.core.permissions import cruds_permissions, schemas_permissions
 from app.core.schools.schools_type import SchoolType
-from app.core.users import cruds_users, models_users, schemas_users
+from app.core.users import cruds_users, models_users
 from app.core.utils import security
 from app.core.utils.config import Settings
 from app.types import core_data
@@ -370,7 +370,7 @@ class MockedPaymentTool(PaymentTool):
         checkout_amount: int,
         checkout_name: str,
         db: AsyncSession,
-        payer_user: schemas_users.CoreUser | None = None,
+        payer_user: schemas_payment.PayerUser,
         redirection_uri: str | None = None,
     ) -> schemas_payment.Checkout:
         exist = await cruds_payment.get_checkout_by_id(mocked_checkout_id, db)

--- a/tests/core/test_mypayment.py
+++ b/tests/core/test_mypayment.py
@@ -2127,7 +2127,7 @@ def test_transfer_with_redirect_url_not_trusted(client: TestClient):
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "Redirect URL is not trusted by hyperion"
+    assert response.json()["detail"] == "Redirect URL is not trusted by Hyperion"
 
 
 def test_transfer_with_unregistered_user(client: TestClient):
@@ -2142,7 +2142,7 @@ def test_transfer_with_unregistered_user(client: TestClient):
     )
 
     assert response.status_code == 404
-    assert response.json()["detail"] == "User is not registered for MyECL Pay"
+    assert response.json()["detail"] == "User is not registered for MyECLPay"
 
 
 def test_transfer_with_too_small_amount(client: TestClient):


### PR DESCRIPTION
## Description

### Related Issues

<!-- If applicable -->
Supersedes these two PRs:
- closes #857
- closes #858

## Changes Made

<!--Please describe the changes made in this pull request-->

- [x] Rewrite of the `PaymentTool.init_checkout()` method to handle at once all the known possible exceptions, with cleaner separation in paragraphs and a bit less nesting (no more try in a try in a try).
- [x] Specific (yet factorized!) error logs, that are short and informative
- [x] New `PayerUser` payment schema to easily pass the 4 desired pieces of information
- [x] Catching exceptions in endpoints that use `init_checkout`

Also fixes the bug introduced in the last release that makes it impossible to retry when it failed due to issues in the payer user's infomation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)

## Impact & Scope

- [x] Core functionality changes
- [ ] Single module changes
- [x] Multiple modules changes
- [ ] Database migrations required
- [ ] Other

## Testing

- [x] Added/modified tests that pass the CI
- [ ] Tested in a pre-prod
- [ ] Tested this locally

## Documentation

- [ ] Updated docs accordingly (docs.myecl.fr) : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] Code includes docstrings
- [ ] No documentation needed
- [x] Inline comments