### PR TITLE
Fix: .env(.template) syntactic coloring and no Copilot access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,10 +24,10 @@
     // We don't want Copilot to be active
     // on config.yaml and dotenv files
     "yaml": false,
-    "dotenv": false
+    "properties": false
   },
   "files.associations": {
-    ".env": "dotenv",
-    ".env.template": "dotenv"
+    ".env": "properties",
+    ".env.template": "properties"
   }
 }


### PR DESCRIPTION
## Description

### Summary

<!--Brief description of what this PR does.-->
Use the `properties` language (it's the built-in name for the "language" used in `.env` files).
- Copilot will still be unable to access it (from this perspective, its just a variable renaming)
- Syntax highlighting added for `.env` (back) and `.env.template` (new)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other

## Testing

- [x] Added/modified tests that pass the CI
- [ ] Tested in a pre-prod
- [x] Tested this locally

## Documentation

- [ ] Updated docs accordingly (docs.myecl.fr) : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] Code includes docstrings
- [ ] No documentation needed