### PR TITLE
Fix: make profile pictures imported in Synapse again

### DIFF
--- a/app/utils/auth/providers.py
+++ b/app/utils/auth/providers.py
@@ -240,7 +240,7 @@ class SynapseAuthClient(BaseAuthClient):
 
         return {
             "sub": user.id,
-            # "picture": f"https://hyperion.myecl.fr/users/{user.id}/profile-picture",
+            "picture": f"https://hyperion.myecl.fr/users/{user.id}/profile-picture",
             # Matrix does not support special characters in username
             "username": username,
             "displayname": user.full_name,


### PR DESCRIPTION
## Description

### Summary

<!--Brief description of what this PR does.-->

Bug: his unexpected comment explains why new users don't have their avatar imported through our SSO to the Matrix server.

Feature: it seems the MAS (Matrix Authentication Service) now supports the `picture` claim of the OIDC scope, so we add it [back].

Source: https://github.com/element-hq/matrix-authentication-service/blob/1bd1b00524a62e365cf06b3745d298a53df69c90/crates/jose/src/claims.rs#L525

## Type of Change

We present it as a feature but it's actually a bug fix...

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: 3rd party service integration

## Testing

- [ ] Added/modified tests that pass the CI
- [ ] Tested in a pre-prod
- [ ] Tested this locally
- [x] Will be tested in prod directly...

## Documentation

- [ ] Updated docs accordingly (docs.myecl.fr) : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] Code includes docstrings
- [x] No documentation needed