### PR TITLE
Fix Redis limiter

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -673,7 +673,9 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
             )
             raise HTTPException(status_code=400, detail="No client information")
 
-        ip_address = request.client.host
+        ip_address = str(
+            request.client.host,
+        )  # host can be an Object of type IPv4Address or IPv6Address and would be refused by redis
         port = request.client.port
         client_address = f"{ip_address}:{port}"
 
@@ -684,7 +686,7 @@ def get_application(settings: Settings, drop_db: bool = False) -> FastAPI:
         if redis_client and settings.ENABLE_RATE_LIMITER:  # If redis is configured
             process, log = limiter(
                 redis_client,
-                str(ip_address),
+                ip_address,
                 settings.REDIS_LIMIT,
                 settings.REDIS_WINDOW,
             )


### PR DESCRIPTION
## Description

### Summary

When using multiple IPs in FORWARDED_ALLOW_IPS variable, request.client.host can be something else than an IP address string and will be wrongly parsed by Redis, implying an error and refusing the connection.

### Changes Made

- [x] Force input data type to string

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)

- [ ] 😶‍🌫️ No impact for the end-users

### Impact & Scope

- [x] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required

- [ ] Other: <!--not module-oriented-->

### Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI
- [ ] 3. Tested in a pre-prod

- [x] 0. Untestable (exceptionally), will be tested in prod directly
Error condition are uncertain and can't be reproduced
### Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [x] `#` Inline comments

- [ ] No documentation needed

</details>
