### PR TITLE
Fix tests_script.py

### DIFF
--- a/tests_script.py
+++ b/tests_script.py
@@ -9,7 +9,13 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 # We ignore .md files and GitHub workflows and app/modules to detect the scope of the changes
-IGNORE_PATHS_START = ("app/modules/", "tests/modules/", "migrations/", ".github/", ".vscode/")
+IGNORE_PATHS_START = (
+    "app/modules/",
+    "tests/modules/",
+    "migrations/",
+    ".github/",
+    ".vscode/",
+)
 IGNORE_EXTENSIONS = (".md",)
 
 


### PR DESCRIPTION
# Description

## Summary

Fix 3 issues :
- Migrations now only trigger test_migrations as intended.
- When using module scope and no tests are detected, no tests should run.
- mod*.py has been removed since we now use folders, and it didn’t work locally and was mostly unnecessary

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on #-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [x] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
