### PR TITLE
Fix(test scope): Coverage flag at the end to prevent pytest from coll…

### DIFF
--- a/tests_script.py
+++ b/tests_script.py
@@ -129,7 +129,6 @@ def run_tests(modules, changed_files, coverage=True, run_all=False):
         logger.info("No tests to run.")
         return None
 
-    logger.info(f"Running tests with command: {' '.join(base_cmd)}")
     return run_command(base_cmd, coverage=coverage)
 
 
@@ -138,6 +137,7 @@ def run_command(base_cmd, coverage):
         base_cmd += [
             "--cov",
         ]
+    logger.info(f"Running command: {' '.join(base_cmd)}")
     sys.exit(subprocess.call(base_cmd))  # noqa: S603
 
 


### PR DESCRIPTION
# Description

## Summary

`pytest --cov tests/modules/sport_competition/` runs all the tests while `pytest tests/modules/sport_competition/ --cov` has the expected behavior

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Distributed the conditional addition of the `--cov` flag

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: Test workflow <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [x] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
