### PR TITLE
Fix(calendar factory): No uppercase

### DIFF
--- a/app/modules/calendar/factory_calendar.py
+++ b/app/modules/calendar/factory_calendar.py
@@ -26,7 +26,7 @@ class CalendarFactory(Factory):
             location="Test location",
             type=CalendarEventType.eventAE,
             description="Test description",
-            decision="Approved",
+            decision=Decision.approved,
             recurrence_rule=None,
         )
         await cruds_calendar.add_event(db, event)

--- a/app/modules/calendar/factory_calendar.py
+++ b/app/modules/calendar/factory_calendar.py
@@ -26,7 +26,7 @@ class CalendarFactory(Factory):
             location="Test location",
             type=CalendarEventType.eventAE,
             description="Test description",
-            decision=Decision.approved,
+            decision=Decision.approved.value,
             recurrence_rule=None,
         )
         await cruds_calendar.add_event(db, event)

--- a/app/modules/calendar/factory_calendar.py
+++ b/app/modules/calendar/factory_calendar.py
@@ -26,7 +26,7 @@ class CalendarFactory(Factory):
             location="Test location",
             type=CalendarEventType.eventAE,
             description="Test description",
-            decision=Decision.approved.value,
+            decision=Decision.approved,
             recurrence_rule=None,
         )
         await cruds_calendar.add_event(db, event)

--- a/app/modules/calendar/factory_calendar.py
+++ b/app/modules/calendar/factory_calendar.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.users.factory_users import CoreUsersFactory
 from app.core.utils.config import Settings
 from app.modules.calendar import cruds_calendar, models_calendar
-from app.modules.calendar.types_calendar import CalendarEventType
+from app.modules.calendar.types_calendar import CalendarEventType, Decision
 from app.types.factory import Factory
 
 


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DONT'T EXPLAIN the code: JUSTIFY what this PR is for!-->

I messed up my local db by running the test workflow on it, so I dropped it, created it, ran the factories, tried to create a calendar event for a future PR, and I got a 500 because the db had "Approved" instead of `Decision.approved.value` whose value is "approved".

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] Use a value

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [x] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: Factory <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
