### PR TITLE
Remove setting breaking Pylance on some installations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,6 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit"
   },
-  // We don't want VS Code to find our dotenv file, as the IDE is not cappable of parsing it correctly.
-  // When using the debugger, VS Code pass the porly parsed file as environnement variables, letting to Pydantic validation erros
-  "python.envFile": "${workspaceFolder}/",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DONT'T EXPLAIN the code: JUSTIFY what this PR is for!-->

On some people's computers, there is no working intellisense, coloration, code completion, etc.
It's broken on a fresh install both Windows and Linux Mint, so that's not an OS issue, nor a conflicting settings issue.

That's due to Pylance.
And removing this old, obsolete setting fixes it.

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] rm obsolete setting

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: `.vscode/settings.json` <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally, on 4 machines (@cotanoine Windows 11, his computer with Windows reinstalled, his computer with Linux Mint instead, and another fresh Windows 11 machine)
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
