### PR TITLE
Fix bank holder name in CGU

### DIFF
--- a/app/core/mypayment/endpoints_mypayment.py
+++ b/app/core/mypayment/endpoints_mypayment.py
@@ -1463,6 +1463,22 @@ async def register_user(
     )
 
 
+async def patch_payment_identity_in_text(
+    text: str,
+    settings: Settings,
+    user: CoreUser,
+    db: AsyncSession,
+) -> str:
+    account_holder = await get_bank_account_holder(user, db)
+    return patch_identity_in_text(
+        text=text,
+        settings=settings,
+    ).replace(
+        "{bank_account_holder}",
+        account_holder.name,
+    )
+
+
 @router.get(
     "/mypayment/users/me/tos",
     status_code=200,
@@ -1492,9 +1508,11 @@ async def get_user_tos(
     return schemas_mypayment.TOSSignatureResponse(
         accepted_tos_version=existing_user_payment.accepted_tos_version,
         latest_tos_version=LATEST_TOS,
-        tos_content=patch_identity_in_text(
+        tos_content=await patch_payment_identity_in_text(
             Path("assets/mypayment-terms-of-service.txt").read_text("utf-8"),
             settings,
+            user,
+            db,
         ),
         max_wallet_balance=settings.MYPAYMENT_MAXIMUM_WALLET_BALANCE,
     )

--- a/app/core/mypayment/endpoints_mypayment.py
+++ b/app/core/mypayment/endpoints_mypayment.py
@@ -1470,13 +1470,14 @@ async def patch_payment_identity_in_text(
     db: AsyncSession,
 ) -> str:
     account_holder = await get_bank_account_holder(user, db)
-    return patch_identity_in_text(
+    patched_text: str = patch_identity_in_text(
         text=text,
         settings=settings,
     ).replace(
         "{bank_account_holder}",
         account_holder.name,
     )
+    return patched_text
 
 
 @router.get(

--- a/app/core/mypayment/utils_mypayment.py
+++ b/app/core/mypayment/utils_mypayment.py
@@ -26,7 +26,7 @@ hyperion_security_logger = logging.getLogger("hyperion.security")
 hyperion_mypayment_logger = logging.getLogger("hyperion.mypayment")
 hyperion_error_logger = logging.getLogger("hyperion.error")
 
-LATEST_TOS = 3
+LATEST_TOS = 4
 QRCODE_EXPIRATION = 5  # minutes
 MYPAYMENT_LOGS_S3_SUBFOLDER = "logs"
 RETENTION_DURATION = 10 * 365  # 10 years in days

--- a/assets/mypayment-terms-of-service.txt
+++ b/assets/mypayment-terms-of-service.txt
@@ -1,4 +1,4 @@
-Version 3
+Version 4
 
 # CGU {payment_name}
 
@@ -13,7 +13,7 @@ Lors de son inscription, l’utilisateur se voit attribuer un portefeuille numé
 La monnaie virtuelle ne peut pas être convertie en euros ou en toute autre devise à cours légal. Elle est non remboursable, non réversible, et ne peut pas être cédée ou transférée à d’autres utilisateurs. Un portefeuille ne peut jamais être en solde négatif.
 
 ## Recharge du portefeuille via HelloAsso
-L’utilisateur peut recharger son portefeuille par carte bancaire via la plateforme HelloAsso. Les fonds seront versés directement sur le compte bancaire de l’association {entity_name}, et un équivalent en est crédité sur le portefeuille numérique de l’utilisateur.
+L’utilisateur peut recharger son portefeuille par carte bancaire via la plateforme HelloAsso. Les fonds seront versés directement sur le compte bancaire de l’association {bank_account_holder}, et un équivalent en est crédité sur le portefeuille numérique de l’utilisateur.
 HelloAsso est une plateforme française de paiement pour les associations, fonctionnant sur un modèle solidaire, garantissant que 100 % de votre paiement sera versé à l’association choisie.
 Elle se finance uniquement par des 'contribution volontaire' et par défaut, HelloAsso proposera à l’utilisateur de faire une 'contribution volontaire', qui peut librement refuser sans que cela empêche la transaction. Si vous choisissez de faire cette contribution, celle-ci soutiendra l’aide qu’HelloAsso apporte aux associations et seul HelloAsso en bénéficiera.
 


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

Change bank account holder name in CGU with the one in database instead of Settings.entity_name

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on #-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [x] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [x] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
