### PR TITLE
Run tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "module"
 asyncio_default_test_loop_scope = "module"
 filterwarnings = ["error", "ignore::DeprecationWarning"]
+addopts = "-n 8 --dist=loadfile" # loadfile makes sure that tests are grouped by their containing file and distributed to available workers as whole units.
 
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,13 @@ ignore_missing_imports = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "module"
 asyncio_default_test_loop_scope = "module"
-filterwarnings = ["error", "ignore::DeprecationWarning"]
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning",
+    # xdist controller imports `app` during collection before per-worker coverage starts;
+    # the warning is benign -- workers still measure correctly.
+    "ignore:Module .* was previously imported, but not measured:coverage.exceptions.CoverageWarning",
+]
 addopts = "-n 8 --dist=loadfile" # loadfile makes sure that tests are grouped by their containing file and distributed to available workers as whole units.
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ google-auth-stubs==0.3.0
 mypy[faster-cache]==1.16.0
 pytest-alembic==0.12.1
 pytest-asyncio==1.3.0
+pytest-xdist==3.8.0
 pytest-cov==6.1.1
 pytest-mock==3.14.1
 pytest==9.0.1

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -181,7 +181,6 @@ school:
 # HELLOASSO_API_BASE should have the format: `api.helloasso-sandbox.com`
 # HelloAsso only allow 20 simultaneous active access token. Note that each Hyperion worker will need its own access token.
 
-MYPAYMENT_MAXIMUM_WALLET_BALANCE: 5000
 HELLOASSO_CONFIGURATIONS: {} # [["name", "helloasso_client_id", "helloasso_client_secret", "helloasso_slug", "redirection_uri"]]
 #  MYECLPAY:
 #    helloasso_client_id: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 from collections.abc import Generator
+from functools import lru_cache
+from unittest.mock import patch
 
+import psycopg
 import pytest
 from fastapi.testclient import TestClient
 
@@ -16,8 +19,57 @@ from tests.commons import (
 )
 
 
+@lru_cache(maxsize=1)
+def _base_settings():
+    """Cached base test settings (no worker-specific overrides), read once per process."""
+    return create_test_settings()
+
+
+def _worker_db_kwargs(worker_id: str) -> dict[str, str]:
+    """Return DB-name override kwargs for a given xdist worker ID."""
+    if worker_id == "master":
+        return {}
+
+    base = _base_settings()
+
+    if base.POSTGRES_DB:
+        return {"POSTGRES_DB": f"{base.POSTGRES_DB}_{worker_id}"}
+
+    raise ValueError(  # noqa: TRY003
+        "POSTGRES_DB must be set in config.yaml for parallel workers to get isolated databases.",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def worker_database(worker_id: str) -> Generator[None]:
+    """Create and tear down a per-worker Postgres DB when running under pytest-xdist."""
+    if worker_id == "master":
+        yield
+        return
+
+    base = _base_settings()
+
+    conn_params = {
+        "host": base.POSTGRES_HOST,
+        "user": base.POSTGRES_USER,
+        "password": base.POSTGRES_PASSWORD,
+        "dbname": base.POSTGRES_DB,
+    }
+    worker_db = f"{base.POSTGRES_DB}_{worker_id}"
+
+    with psycopg.connect(**conn_params, autocommit=True) as conn:
+        # Drop first to handle leftover DBs from interrupted previous runs
+        conn.execute(f'DROP DATABASE IF EXISTS "{worker_db}"')
+        conn.execute(f'CREATE DATABASE "{worker_db}"')
+
+    yield
+
+    with psycopg.connect(**conn_params, autocommit=True) as conn:
+        conn.execute(f'DROP DATABASE "{worker_db}" WITH (FORCE)')
+
+
 @pytest.fixture(scope="module", autouse=True)
-def client(request) -> Generator[TestClient]:
+def client(request, worker_id: str) -> Generator[TestClient]:
     """
     TestClient fixture.
 
@@ -35,6 +87,7 @@ def client(request) -> Generator[TestClient]:
 
     commons.SETTINGS = create_test_settings(
         USE_FACTORIES=use_factory,
+        **_worker_db_kwargs(worker_id),
     )
 
     test_app = get_application(
@@ -47,5 +100,13 @@ def client(request) -> Generator[TestClient]:
 
     # The TestClient should be used as a context manager in order for the lifespan to be called
     # See https://www.starlette.io/lifespan/#running-lifespan-in-tests
-    with TestClient(test_app) as client:
+    #
+    # Patch get_number_of_workers to return 1 so that use_lock_for_workers always runs
+    # init_db directly. Without this, xdist workers are seen as siblings of the pytest
+    # controller's children, causing get_number_of_workers() to return N > 1 and the
+    # locking logic to skip init_db on all but one worker, leaving DBs without tables.
+    with (
+        patch("app.utils.initialization.get_number_of_workers", return_value=1),
+        TestClient(test_app) as client,
+    ):
         yield client


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

Test suite was running all modules serially (> 3min), with profiling showing that 100% of the overhead was in the setup phase (~3–5s per module × 35 modules). This PR runs test modules in parallel using pytest-xdist which brings total runtime to ~60s.

A problem occured with isolation: each xdist worker (gw0, gw1, …) gets its own dedicated PostgreSQL database (hyperion_gw0, etc.) created at session start and dropped at teardown, so parallel workers never share state. 

A secondary issue is that `get_number_of_workers()` in `initialization.py` uses `psutil` to count children of the parent process — with xdist that counts the other workers rather than app workers — causing `use_lock_for_workers` to skip `init_db` on all but one worker. This is patched/tricked in the client fixture.



...

<!--#### Sources at the end-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] add `pytest-xdist` to requirements-dev.txt
- [x] modified default tests conf  to run tests with 8 workers
- [x]  

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [x] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
