### PR TITLE
fix : runing test with coverage on a specific file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,8 @@ filterwarnings = [
     # xdist controller imports `app` during collection before per-worker coverage starts;
     # the warning is benign -- workers still measure correctly.
     "ignore:Module .* was previously imported, but not measured:coverage.exceptions.CoverageWarning",
+    # idle xdist workers (no tests assigned) produce no coverage data; expected when running a subset of files.
+    "ignore:No data was collected:coverage.exceptions.CoverageWarning",
 ]
 addopts = "-n 8 --dist=loadfile" # loadfile makes sure that tests are grouped by their containing file and distributed to available workers as whole units.
 

--- a/tests_script.py
+++ b/tests_script.py
@@ -101,11 +101,9 @@ def get_other_tests_patterns(changed_files: list[str]) -> list[str]:
     return patterns
 
 
-def run_tests(modules, changed_files, coverage=True, run_all=False):
+def run_tests(modules, changed_files, nb_workers=8, coverage=True, run_all=False):
     """Run tests based on changed modules."""
-    base_cmd = [
-        "pytest",
-    ]
+    base_cmd = ["pytest", f"-n{nb_workers}"]
 
     if run_all:
         logger.info("Running all tests.")
@@ -154,10 +152,14 @@ if __name__ == "__main__":
     # If so, we run tests only for those modules
     if scope_only:
         logger.info("Changes are module-scoped only.")
+
+        # Detect the number of modules to choose a correct number of workers for pytest-xdist
+        n = min(len(changed_files), 8)  # Limit to 8 workers
+
         modules = detect_modules(changed_files)
-        run_tests(modules, changed_files, coverage=coverage)
+        run_tests(modules, changed_files, nb_workers=n, coverage=coverage)
     # Else
     else:
         logger.info("Changes affect broader scope, running all tests.")
         modules = []
-        run_tests(modules, changed_files, coverage=coverage, run_all=True)
+        run_tests(modules, changed_files, nb_workers=8, coverage=coverage, run_all=True)


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

Since tests parallelization, running tests with coverage on a specific file fails and no tests run. A fix is to ignore the warning raised by coverage. 

...

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->


## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] edit `pyproject.toml` to ignore warning

<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [x] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [x] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [x] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [x] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

</details>
