### PR TITLE
validate purchases on full cdr payment

### DIFF
--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2696,10 +2696,31 @@ async def create_payment(
         action=str(db_payment.__dict__),
         timestamp=datetime.now(UTC),
     )
-
     cruds_cdr.create_payment(db, db_payment)
     cruds_cdr.create_action(db, db_action)
     await db.flush()
+    purchases = await cruds_cdr.get_purchases_by_user_id(
+        db=db,
+        user_id=user_id,
+        cdr_year=cdr_year.year,
+    )
+    payments = await cruds_cdr.get_payments_by_user_id(
+        db=db,
+        user_id=user_id,
+        cdr_year=cdr_year.year,
+    )
+    purchases_total = sum(
+        purchase.product_variant.price * purchase.quantity for purchase in purchases
+    )
+    payments_total = sum(payment.total for payment in payments)
+    if purchases_total - payments_total <= 0:
+        for purchase in purchases:
+            await cruds_cdr.mark_purchase_as_validated(
+                db=db,
+                user_id=user_id,
+                product_variant_id=purchase.product_variant.id,
+                validated=True,
+            )
     return db_payment
 
 


### PR DESCRIPTION
# Description

Currently, all purchases have to be validated in person. However, if paid on site, the same person collecting the payment has to then manually validate purchases, despite having checked them already before asking for the payment. Thus, we want, for ease of use, to validate all purchases automatically if the full payment has been made on site.

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->
Added a check when an admin adds a payment to see if the full amount has been paid. If so, validate all purchases.

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on #-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [x] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [x] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>
