### PR TITLE
Parse raid information dates in migration

### DIFF
--- a/migrations/versions/63-raid_editions_and_state.py
+++ b/migrations/versions/63-raid_editions_and_state.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, date, datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -90,8 +91,14 @@ def upgrade() -> None:
             id=DEFAULT_EDITION_ID,
             year=2026,
             name="Raid",
-            start_date=raid_start_date,
-            end_date=raid_end_date,
+            start_date=datetime.strptime(raid_start_date, "%Y-%m-%d")
+            .astimezone(UTC)
+            .date()
+            if raid_start_date
+            else None,
+            end_date=datetime.strptime(raid_end_date, "%Y-%m-%d").astimezone(UTC).date()
+            if raid_end_date
+            else None,
             registering_end_date=raid_registering_end_date,
         ),
     )

--- a/migrations/versions/63-raid_editions_and_state.py
+++ b/migrations/versions/63-raid_editions_and_state.py
@@ -7,7 +7,7 @@ import contextlib
 import json
 import uuid
 from collections.abc import Sequence
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "AEECL ECLAIR" }]
 
 # Hyperion follows Semantic Versioning
 # https://semver.org/
-version = "5.4.0"
+version = "5.4.1"
 requires-python = ">= 3.12, < 3.15"
 
 license = "MIT"


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->

...

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on #-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [ ] No documentation needed

</details>
