### PR TITLE
[Hot fix] Allow pkce with client secret

### DIFF
--- a/app/core/auth/endpoints_auth.py
+++ b/app/core/auth/endpoints_auth.py
@@ -517,21 +517,23 @@ async def authorization_code_grant(
 
     if auth_client.secret is not None:
         # As PKCE is not used, we need to make sure that PKCE related parameters were not used
-        if (
-            db_authorization_code.code_challenge is not None
-            or tokenreq.code_verifier is not None
-        ):
-            # We allow some auth clients to bypass this verification
-            # because some auth providers may use PKCE with a client secret event if it's forbidden by the specifications
-            if not auth_client.allow_pkce_with_client_secret:
-                hyperion_access_logger.warning(
-                    f"Token authorization_code_grant: PKCE related parameters should not be used when using a client secret ({request_id})",
-                )
-                raise AuthHTTPException(
-                    status_code=400,
-                    error="invalid_request",
-                    error_description="PKCE related parameters should not be used",
-                )
+        # 16/08/2026: As a hotfix, we allow all clients to use PKCE with a client secret
+        pass
+        # if (
+        #     db_authorization_code.code_challenge is not None
+        #     or tokenreq.code_verifier is not None
+        # ):
+        #     # We allow some auth clients to bypass this verification
+        #     # because some auth providers may use PKCE with a client secret event if it's forbidden by the specifications
+        #     if not auth_client.allow_pkce_with_client_secret:
+        #         hyperion_access_logger.warning(
+        #             f"Token authorization_code_grant: PKCE related parameters should not be used when using a client secret ({request_id})",
+        #         )
+        #         raise AuthHTTPException(
+        #             status_code=400,
+        #             error="invalid_request",
+        #             error_description="PKCE related parameters should not be used",
+        #         )
     elif (
         db_authorization_code.code_challenge is not None
         and tokenreq.code_verifier is not None


### PR DESCRIPTION
# Description

## Summary

<!--BRIEF description: DON'T EXPLAIN the code: JUSTIFY what this PR is for!-->
We are forced to allow pkce with client secret even if it does not comply tothe OIDC specs.
...

<!--#### Sources at the end-->

## Issues/PR dependencies

<!--Use a keyword, then #123 for the same repo or aeecleclair/RepoName#123 for another-->

### Issues to be resolved

<!--Keywords: "closes", "fixes", "resolves" -->
<!--Fixes #-->

### Required PRs

<!--Keywords: "depends on", "blocked by" -->
<!--Depends on #-->

## Changes Made

<!--DESCRIBE the changes: tell the BIG STEPS, use a CHECKLIST to show progress. You can explain below how the code works.-->

- [x] ...
- [ ] ...

## Additional Notes

<!--Anything relevant that does not quite fit in the summary-->

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [x] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [x] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [ ] No documentation needed

</details>
