### PR TITLE
Allow admins to create CDR checkout for users

### DIFF
--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2826,6 +2826,7 @@ async def delete_payment(
     status_code=200,
 )
 async def get_payment_url(
+    user_id: str | None = None,
     db: AsyncSession = Depends(get_db),
     user: models_users.CoreUser = Depends(
         is_user_allowed_to([CdrPermissions.access_cdr]),
@@ -2838,14 +2839,34 @@ async def get_payment_url(
     Get payment url
     """
 
+    target_user = user
+
+    if user_id is not None and user_id != user.id:
+        if not await has_user_permission(user, CdrPermissions.manage_cdr, db):
+            raise HTTPException(
+                status_code=403,
+                detail="You're not allowed to create a payment for another user.",
+            )
+
+        target_user = await get_user_by_id(
+            db=db,
+            user_id=user_id,
+        )
+
+        if target_user is None:
+            raise HTTPException(
+                status_code=404,
+                detail="User not found.",
+            )
+
     purchases = await cruds_cdr.get_purchases_by_user_id(
         db=db,
-        user_id=user.id,
+        user_id=target_user.id,
         cdr_year=cdr_year.year,
     )
     payments = await cruds_cdr.get_payments_by_user_id(
         db=db,
-        user_id=user.id,
+        user_id=target_user.id,
         cdr_year=cdr_year.year,
     )
 
@@ -2861,28 +2882,30 @@ async def get_payment_url(
             status_code=403,
             detail="Please give an amount in cents, greater than 1€.",
         )
+
     user_schema = schemas_users.CoreUser(
-        account_type=user.account_type,
-        school_id=user.school_id,
-        email=user.email,
-        birthday=user.birthday,
-        promo=user.promo,
-        floor=user.floor,
-        phone=user.phone,
-        created_on=user.created_on,
+        account_type=target_user.account_type,
+        school_id=target_user.school_id,
+        email=target_user.email,
+        birthday=target_user.birthday,
+        promo=target_user.promo,
+        floor=target_user.floor,
+        phone=target_user.phone,
+        created_on=target_user.created_on,
         groups=[
             schemas_groups.CoreGroupSimple(
                 id=group.id,
                 name=group.name,
                 description=group.description,
             )
-            for group in user.groups
+            for group in target_user.groups
         ],
-        id=user.id,
-        name=user.name,
-        firstname=user.firstname,
-        nickname=user.nickname,
+        id=target_user.id,
+        name=target_user.name,
+        firstname=target_user.firstname,
+        nickname=target_user.nickname,
     )
+
     checkout = await payment_tool.init_checkout(
         module=module.root,
         checkout_amount=amount,
@@ -2895,7 +2918,7 @@ async def get_payment_url(
         db=db,
         checkout=models_cdr.Checkout(
             id=uuid4(),
-            user_id=user.id,
+            user_id=target_user.id,
             checkout_id=checkout.id,
         ),
     )

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2826,7 +2826,7 @@ async def delete_payment(
     status_code=200,
 )
 async def get_payment_url(
-    target_user_id: str | None = None,
+    payment_request: schemas_cdr.PaymentUrlRequest | None = None,
     db: AsyncSession = Depends(get_db),
     user: models_users.CoreUser = Depends(
         is_user_allowed_to([CdrPermissions.access_cdr]),
@@ -2838,6 +2838,10 @@ async def get_payment_url(
     """
     Get payment url
     """
+
+    target_user_id = (
+        payment_request.target_user_id if payment_request is not None else None
+    )
 
     target_user = user
 

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2826,7 +2826,7 @@ async def delete_payment(
     status_code=200,
 )
 async def get_payment_url(
-    user_id: str | None = None,
+    target_user_id: str | None = None,
     db: AsyncSession = Depends(get_db),
     user: models_users.CoreUser = Depends(
         is_user_allowed_to([CdrPermissions.access_cdr]),
@@ -2841,7 +2841,7 @@ async def get_payment_url(
 
     target_user = user
 
-    if user_id is not None and user_id != user.id:
+    if target_user_id is not None and target_user_id != user.id:
         if not await has_user_permission(user, CdrPermissions.manage_cdr, db):
             raise HTTPException(
                 status_code=403,
@@ -2850,7 +2850,7 @@ async def get_payment_url(
 
         requested_user = await get_user_by_id(
             db=db,
-            user_id=user_id,
+            user_id=target_user_id,
         )
 
         if requested_user is None:

--- a/app/modules/cdr/endpoints_cdr.py
+++ b/app/modules/cdr/endpoints_cdr.py
@@ -2848,16 +2848,18 @@ async def get_payment_url(
                 detail="You're not allowed to create a payment for another user.",
             )
 
-        target_user = await get_user_by_id(
+        requested_user = await get_user_by_id(
             db=db,
             user_id=user_id,
         )
 
-        if target_user is None:
+        if requested_user is None:
             raise HTTPException(
                 status_code=404,
                 detail="User not found.",
             )
+
+        target_user = requested_user
 
     purchases = await cruds_cdr.get_purchases_by_user_id(
         db=db,

--- a/app/modules/cdr/schemas_cdr.py
+++ b/app/modules/cdr/schemas_cdr.py
@@ -252,6 +252,10 @@ class PaymentComplete(PaymentBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PaymentUrlRequest(BaseModel):
+    target_user_id: str | None = None
+
+
 class PaymentUrl(BaseModel):
     url: str
 

--- a/tests/modules/cdr/test_cdr.py
+++ b/tests/modules/cdr/test_cdr.py
@@ -2865,7 +2865,7 @@ async def test_customdata_deletion_on_purchase_deletion(client: TestClient):
 async def test_pay_admin_for_user(client: TestClient):
     response = client.post(
         "/cdr/pay/",
-        params={
+        json={
             "target_user_id": cdr_user_with_curriculum_with_non_validated_purchase.id,
         },
         headers={"Authorization": f"Bearer {token_admin}"},
@@ -2878,7 +2878,7 @@ async def test_pay_admin_for_user(client: TestClient):
 def test_pay_other_user_forbidden(client: TestClient):
     response = client.post(
         "/cdr/pay/",
-        params={"target_user_id": user.id},
+        json={"target_user_id": user.id},
         headers={"Authorization": f"Bearer {token_bde}"},
     )
 

--- a/tests/modules/cdr/test_cdr.py
+++ b/tests/modules/cdr/test_cdr.py
@@ -2860,3 +2860,26 @@ async def test_customdata_deletion_on_purchase_deletion(client: TestClient):
         headers={"Authorization": f"Bearer {token_admin}"},
     )
     assert response.status_code == 404
+
+
+async def test_pay_admin_for_user(client: TestClient):
+    response = client.post(
+        "/cdr/pay/",
+        params={
+            "user_id": cdr_user_with_curriculum_with_non_validated_purchase.id,
+        },
+        headers={"Authorization": f"Bearer {token_admin}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://some.url.fr/checkout"
+
+
+def test_pay_other_user_forbidden(client: TestClient):
+    response = client.post(
+        "/cdr/pay/",
+        params={"user_id": user.id},
+        headers={"Authorization": f"Bearer {token_bde}"},
+    )
+
+    assert response.status_code == 403

--- a/tests/modules/cdr/test_cdr.py
+++ b/tests/modules/cdr/test_cdr.py
@@ -2866,7 +2866,7 @@ async def test_pay_admin_for_user(client: TestClient):
     response = client.post(
         "/cdr/pay/",
         params={
-            "user_id": cdr_user_with_curriculum_with_non_validated_purchase.id,
+            "target_user_id": cdr_user_with_curriculum_with_non_validated_purchase.id,
         },
         headers={"Authorization": f"Bearer {token_admin}"},
     )
@@ -2878,7 +2878,7 @@ async def test_pay_admin_for_user(client: TestClient):
 def test_pay_other_user_forbidden(client: TestClient):
     response = client.post(
         "/cdr/pay/",
-        params={"user_id": user.id},
+        params={"target_user_id": user.id},
         headers={"Authorization": f"Bearer {token_bde}"},
     )
 


### PR DESCRIPTION
# Description

## Summary

Allow CDR administrators to generate a HelloAsso checkout for another user, enabling in-person payment through a QR code while keeping the existing user payment flow unchanged.

## Issues/PR dependencies

### Issues to be resolved

### Required PRs

## Changes Made

- [x] Allow `/cdr/pay/` to receive an optional user ID
- [x] Keep the existing self-payment behavior when no user ID is provided
- [x] Require CDR management permission when generating a checkout for another user
- [x] Calculate purchases, payments and remaining amount for the selected user
- [x] Associate the HelloAsso checkout with the selected user
- [x] Add tests for admin checkout generation
- [x] Add a test preventing unauthorized users from generating a checkout for another user
- [x] Keep the existing self-payment test

## Additional Notes

<img width="1657" height="876" alt="image" src="https://github.com/user-attachments/assets/6fcd9d5a-162f-4c89-8646-05911033f67b" />


No database migration is required.

The existing HelloAsso payment confirmation flow is reused, since the generated checkout is associated with the selected user's ID.

<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [x] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ...

## Testing

- [x] 1. Tested this locally
- [x] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly :
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [x] No documentation needed

</details>