### PR TITLE
Remove permissions admin bypass

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -522,8 +522,6 @@ def is_user_allowed_to(
         """
         A dependency that checks that user has the permission with the given name then returns the corresponding user.
         """
-        if GroupType.admin in [group.id for group in user.groups]:
-            return user
 
         allowed_group_ids: list[str] = []
         allowed_account_types: list[AccountType] = []


### PR DESCRIPTION
# Description

## Summary

Don't allow Admins to bypass permissions. The bypass:
- could encourage admin to perform actions there were not authorized to do, and especially access sensitive information from other associations
- should not be useful as admins don't have access to corresponding frontend and are not supposed to use these endpoints

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [x] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [ ] No documentation needed

</details>
