### PR TITLE
is_user_allowed_to docstring

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -511,6 +511,8 @@ def is_user_allowed_to(
         * make sure the user making the request exists
         * make sure the user has the permission with the given name
         * return the corresponding user `models_users.CoreUser` object
+
+    The user need to have at least ONE of the permissions in the list to be allowed to access the endpoint.
     """
 
     async def is_user_allowed_to(
@@ -528,18 +530,22 @@ def is_user_allowed_to(
         allowed_group_ids: list[str] = []
         allowed_account_types: list[AccountType] = []
         for permission_name in permissions_name:
-            allowed_group_ids += (
-                await cruds_permissions.get_permissions_by_permission_name(
-                    db,
-                    permission_name,
-                )
-            ).groups
-            allowed_account_types += (
-                await cruds_permissions.get_permissions_by_permission_name(
-                    db,
-                    permission_name,
-                )
-            ).account_types
+            allowed_group_ids.extend(
+                (
+                    await cruds_permissions.get_permissions_by_permission_name(
+                        db,
+                        permission_name,
+                    )
+                ).groups,
+            )
+            allowed_account_types.extend(
+                (
+                    await cruds_permissions.get_permissions_by_permission_name(
+                        db,
+                        permission_name,
+                    )
+                ).account_types,
+            )
 
         if (
             not any(

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -512,7 +512,7 @@ def is_user_allowed_to(
         * make sure the user has the permission with the given name
         * return the corresponding user `models_users.CoreUser` object
 
-    The user need to have at least ONE of the permissions in the list to be allowed to access the endpoint.
+    The query is a _logical OR_: the user needs to have at least ONE of the permissions in the list to be allowed to access the endpoint.
     """
 
     async def is_user_allowed_to(


### PR DESCRIPTION
# Description

## Summary

Explain that users need at least one valid permission to access the endpoint

Replace `+=` by `extend` as addition between lists is considered a bad practice in terms of performance

<!--Don't touch thses two tags-->
<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [ ] No documentation needed

</details>
